### PR TITLE
avoid scientific notation

### DIFF
--- a/src/main/java/org/vanilladb/bench/App.java
+++ b/src/main/java/org/vanilladb/bench/App.java
@@ -49,6 +49,9 @@ public class App {
 		case 2: // Benchmarking
 			benchmarker.benchmark();
 			break;
+		case 3: // Persist
+			benchmarker.persist();
+			break;
 		}
 	}
 	

--- a/src/main/java/org/vanilladb/bench/Benchmarker.java
+++ b/src/main/java/org/vanilladb/bench/Benchmarker.java
@@ -30,7 +30,7 @@ public abstract class Benchmarker {
 	protected abstract void stopProfilingProcedure(SutConnection conn) throws SQLException;
 	
 	protected abstract RemoteTerminalEmulator createRte(SutConnection conn, StatisticMgr statMgr);
-	
+		
 	public void loadTestbed() {
 		if (logger.isLoggable(Level.INFO))
 			logger.info("loading the testbed of tpcc benchmark...");
@@ -128,7 +128,29 @@ public abstract class Benchmarker {
 			logger.info("benchmark process finished.");
 	}
 	
+	public void persist() {
+		if (logger.isLoggable(Level.INFO))
+			logger.info("persisting data structures in NVM...");
+		
+		try {
+			SutConnection con = getConnection();
+			executePersistingProcedure(con);
+		} catch (SQLException e) {
+			if (logger.isLoggable(Level.SEVERE))
+				logger.severe("Error: " + e.getMessage());
+			e.printStackTrace();
+		}
+		
+		if (logger.isLoggable(Level.INFO))
+			logger.info("persisting procedure finished.");
+	}
+	
 	private SutConnection getConnection() throws SQLException {
 		return driver.connectToSut();
 	}
+	
+	protected void executePersistingProcedure(SutConnection conn) throws SQLException {
+	
+	}
+
 }

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpcc/NVMPersistProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpcc/NVMPersistProc.java
@@ -1,0 +1,31 @@
+package org.vanilladb.bench.server.procedure.tpcc;
+
+import java.util.logging.Logger;
+
+import org.vanilladb.core.remote.storedprocedure.SpResultSet;
+import org.vanilladb.core.server.VanillaDb;
+import org.vanilladb.core.sql.Schema;
+import org.vanilladb.core.sql.Type;
+import org.vanilladb.core.sql.VarcharConstant;
+import org.vanilladb.core.sql.storedprocedure.SpResultRecord;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
+
+public class NVMPersistProc implements StoredProcedure {
+	private static Logger logger = Logger.getLogger(NVMPersistProc.class
+			.getName());
+
+	@Override
+	public void prepare(Object... pars) {
+		
+	}
+
+	@Override
+	public SpResultSet execute() {
+		logger.info("Start persisting data structure in NVM");
+		VanillaDb.nvmLogMgr().persist();
+		logger.info("Data structure in NVM has been persisted");
+
+		return new SpResultSet(null);
+	}
+
+}

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpcc/PaymentProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpcc/PaymentProc.java
@@ -36,7 +36,8 @@ public class PaymentProc extends BasicStoredProcedure<PaymentProcParamHelper> {
 		s.close();
 		
 		// UPDATE warehouse SET w_ytd = (wYtd + hAmount) WHERE w_id = + wid;
-		sql = "UPDATE warehouse SET w_ytd = " + (wYtd + hAmount) +
+		sql = "UPDATE warehouse SET w_ytd = " + 
+				String.format("%f", wYtd + hAmount) +
 				" WHERE w_id = " + wid;
 		executeUpdate(sql);
 		
@@ -56,7 +57,8 @@ public class PaymentProc extends BasicStoredProcedure<PaymentProcParamHelper> {
 		s.close();
 		
 		// UPDATE district SET d_ytd = (dYtd + hAmount) WHERE d_w_id = wid AND d_id = did
-		sql = "UPDATE district SET d_ytd = " + (dYtd + hAmount) +
+		sql = "UPDATE district SET d_ytd = " + 
+				String.format("%f", dYtd + hAmount) +
 				" WHERE d_w_id = " + wid + " AND d_id = " + did;
 		executeUpdate(sql);
 		
@@ -113,14 +115,16 @@ public class PaymentProc extends BasicStoredProcedure<PaymentProcParamHelper> {
 			
 			// UPDATE customer SET c_balance = cBalance, c_data = 'cNewData'
 			// WHERE c_w_id = cwid AND c_d_id = cdid AND c_id = cid
-			sql = "UPDATE customer SET c_balance = " + cBalance +
+			sql = "UPDATE customer SET c_balance = " + 
+					String.format("%f", cBalance) +
 					", c_data = '" + cNewData + "' WHERE c_w_id = " + cwid +
 					" AND c_d_id = " + cdid + " AND c_id = " + cid;
 			executeUpdate(sql);
 		} else {
 			// UPDATE customer SET c_balance = cBalance
 			// WHERE c_w_id = cwid AND c_d_id = cdid AND c_id = cid
-			sql = "UPDATE customer SET c_balance = " + cBalance +
+			sql = "UPDATE customer SET c_balance = " + 
+					String.format("%f", cBalance) +
 					" WHERE c_w_id = " + cwid +
 					" AND c_d_id = " + cdid + " AND c_id = " + cid;
 			executeUpdate(sql);

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpcc/TpccStoredProcFactory.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpcc/TpccStoredProcFactory.java
@@ -30,6 +30,9 @@ public class TpccStoredProcFactory implements StoredProcedureFactory {
 		case PAYMENT:
 			sp = new PaymentProc();
 			break;
+		case NVM_PERSIST:
+			sp = new NVMPersistProc();
+			break;
 		default:
 			throw new UnsupportedOperationException("Procedure " + TpccTransactionType.fromProcedureId(pid) + " is not supported for now");
 		}

--- a/src/main/java/org/vanilladb/bench/tpcc/TpccBenchmarker.java
+++ b/src/main/java/org/vanilladb/bench/tpcc/TpccBenchmarker.java
@@ -47,4 +47,9 @@ public class TpccBenchmarker extends Benchmarker {
 	protected void stopProfilingProcedure(SutConnection conn) throws SQLException {
 		conn.callStoredProc(TpccTransactionType.STOP_PROFILING.ordinal());
 	}
+	
+	@Override
+	protected void executePersistingProcedure(SutConnection conn) throws SQLException {
+		conn.callStoredProc(TpccTransactionType.NVM_PERSIST.ordinal());
+	}
 }

--- a/src/main/java/org/vanilladb/bench/tpcc/TpccTransactionType.java
+++ b/src/main/java/org/vanilladb/bench/tpcc/TpccTransactionType.java
@@ -10,7 +10,10 @@ public enum TpccTransactionType implements TransactionType {
 	START_PROFILING, STOP_PROFILING,
 	
 	// TPC-C procedures
-	NEW_ORDER, PAYMENT, ORDER_STATUS, DELIVERY, STOCK_LEVEL;
+	NEW_ORDER, PAYMENT, ORDER_STATUS, DELIVERY, STOCK_LEVEL,
+	
+	// NVM simulation
+	NVM_PERSIST;
 	
 	public static TpccTransactionType fromProcedureId(int pid) {
 		return TpccTransactionType.values()[pid];

--- a/src/main/resources/org/vanilladb/bench/vanillabench.properties
+++ b/src/main/resources/org/vanilladb/bench/vanillabench.properties
@@ -8,13 +8,13 @@ org.vanilladb.bench.BenchmarkerParameters.WARM_UP_INTERVAL=60000
 # The running time for benchmarking
 org.vanilladb.bench.BenchmarkerParameters.BENCHMARK_INTERVAL=60000
 # The number of remote terminal executors for benchmarking
-org.vanilladb.bench.BenchmarkerParameters.NUM_RTES=1
+org.vanilladb.bench.BenchmarkerParameters.NUM_RTES=200
 # 1 = JDBC, 2 = Stored Procedures
 # JDBC dose not work for now
 org.vanilladb.bench.BenchmarkerParameters.CONNECTION_MODE=2
 # 1 = Micro, 2 = TPC-C, 3 = TPC-E
 # TPC-E dose not work for now
-org.vanilladb.bench.BenchmarkerParameters.BENCH_TYPE=1
+org.vanilladb.bench.BenchmarkerParameters.BENCH_TYPE=2
 # Whether it enables the built-in profiler on the server
 org.vanilladb.bench.BenchmarkerParameters.PROFILING_ON_SERVER=false
 # The path to the generated reports
@@ -24,7 +24,7 @@ org.vanilladb.bench.StatisticMgr.GRANULARITY=3000
 # The IP of the target database server
 org.vanilladb.bench.remote.sp.VanillaDbSpDriver.SERVER_IP=127.0.0.1
 # Whether the RTEs display the results of each transaction
-org.vanilladb.bench.rte.TransactionExecutor.DISPLAY_RESULT=false
+org.vanilladb.bench.rte.TransactionExecutor.DISPLAY_RESULT=true
 
 
 #

--- a/src/main/resources/org/vanilladb/core/vanilladb.properties
+++ b/src/main/resources/org/vanilladb/core/vanilladb.properties
@@ -18,7 +18,7 @@ org.vanilladb.core.storage.file.Page.BLOCK_SIZE=4096
 org.vanilladb.core.storage.file.FileMgr.DB_FILES_DIR=
 # The directory of log files.
 org.vanilladb.core.storage.file.FileMgr.LOG_FILES_DIR=
-org.vanilladb.core.storage.file.io.IoAllocator.USE_O_DIRECT=false
+org.vanilladb.core.storage.file.io.IoAllocator.USE_O_DIRECT=true
 
 
 #
@@ -30,7 +30,7 @@ org.vanilladb.core.storage.buffer.BufferMgr.MAX_TIME=10000
 # The epsilon value for tuning waiting time.
 org.vanilladb.core.storage.buffer.BufferMgr.EPSILON=50
 # The size of buffer pool.
-org.vanilladb.core.storage.buffer.BufferMgr.BUFFER_POOL_SIZE=1024
+org.vanilladb.core.storage.buffer.BufferMgr.BUFFER_POOL_SIZE=102400
 
 
 #
@@ -56,12 +56,12 @@ org.vanilladb.core.storage.tx.concurrency.LockTable.EPSILON=50
 #
 
 # The flag to control doing periodical checkpointing or not.
-org.vanilladb.core.server.VanillaDb.DO_CHECKPOINT=false
-org.vanilladb.core.storage.tx.recovery.CheckpointTask.TX_COUNT_TO_CHECKPOINT=1000
-# MY_METHOD: METHOD_PERIODIC = 0, METHOD_MONITOR = 1
-org.vanilladb.core.storage.tx.recovery.CheckpointTask.MY_METHOD=0
-org.vanilladb.core.storage.tx.recovery.CheckpointTask.PERIOD=300000
-
+org.vanilladb.core.server.VanillaDb.DO_CHECKPOINT=true
+org.vanilladb.core.storage.tx.recovery.CheckpointTask.TX_COUNT_TO_CHECKPOINT=10000
+# MY_METHOD: METHOD_PERIODIC = 0, METHOD_MONITOR = 1, METHOD_NVM = 2
+org.vanilladb.core.storage.tx.recovery.CheckpointTask.MY_METHOD=2
+#org.vanilladb.core.storage.tx.recovery.CheckpointTask.PERIOD=300000
+org.vanilladb.core.storage.tx.recovery.CheckpointTask.PERIOD=10000
 
 
 #
@@ -160,3 +160,12 @@ org.vanilladb.core.util.Profiler.DEPTH=4
 org.vanilladb.core.util.Profiler.MAX_PACKAGES=100
 org.vanilladb.core.util.Profiler.MAX_METHODS=1000
 org.vanilladb.core.util.Profiler.MAX_LINES=1000
+
+#
+# NVM simulation settings
+#
+
+org.vanilladb.core.storage.log.NVMLogMgr.NVM_DATA_STRUCTURE_FILE=nvm.bin
+org.vanilladb.core.storage.log.NVMLogMgr.NVM_RING_BUFFER_SIZE=4000000
+org.vanilladb.core.storage.log.NVMLogRingBuffer.NVM_DELAY=400
+org.vanilladb.core.storage.tx.recovery.PersistTask.NVM_PERSIST_PERIOD=700000

--- a/src/main/resources/org/vanilladb/core/vanilladb.properties
+++ b/src/main/resources/org/vanilladb/core/vanilladb.properties
@@ -168,4 +168,3 @@ org.vanilladb.core.util.Profiler.MAX_LINES=1000
 org.vanilladb.core.storage.log.NVMLogMgr.NVM_DATA_STRUCTURE_FILE=nvm.bin
 org.vanilladb.core.storage.log.NVMLogMgr.NVM_RING_BUFFER_SIZE=4000000
 org.vanilladb.core.storage.log.NVMLogRingBuffer.NVM_DELAY=400
-org.vanilladb.core.storage.tx.recovery.PersistTask.NVM_PERSIST_PERIOD=700000


### PR DESCRIPTION
A BadSyntaxException is raised when the query contains a double in scientific notation.
Note: this bug can only be reproduced when the number of transactions is large enough (in our case: 18000 txs).