### PR TITLE
Fix the bug casuing RuntimeException during updating

### DIFF
--- a/src/main/java/org/vanilladb/bench/server/procedure/BasicStoredProcedure.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/BasicStoredProcedure.java
@@ -74,11 +74,6 @@ public abstract class BasicStoredProcedure<H extends StoredProcedureParamHelper>
 	}
 	
 	protected void executeUpdate(String sql) {
-		int count = VanillaDb.newPlanner().executeUpdate(sql, tx);
-		
-		if (count > 1)
-			throw new RuntimeException("Update: '" + sql + "' affect more than 1 record.");
-		else if (count < 1)
-			throw new RuntimeException("Update: '" + sql + "' fails.");
+		VanillaDb.newPlanner().executeUpdate(sql, tx);
 	}
 }


### PR DESCRIPTION
During updating using stored procedures, `RuntimeException` may happen since `BasicStoredProcedure.executeUpdate` assumes that each update should return exactly `1`.