### PR TITLE
Refactor the code and put general configurations in a single class

### DIFF
--- a/src/main/java/org/vanilladb/bench/Benchmark.java
+++ b/src/main/java/org/vanilladb/bench/Benchmark.java
@@ -32,7 +32,7 @@ public abstract class Benchmark {
 	}
 	
 	public int getNumOfRTEs() {
-		return BenchmarkerParameters.NUM_RTES;
+		return VanillaBenchParameters.NUM_RTES;
 	}
 	
 	public abstract Set<BenchTransactionType> getBenchmarkingTxTypes();
@@ -41,7 +41,8 @@ public abstract class Benchmark {
 	
 	public abstract boolean executeDatabaseCheckProcedure(SutConnection conn) throws SQLException;
 	
-	public abstract RemoteTerminalEmulator<?> createRte(SutConnection conn, StatisticMgr statMgr);
+	public abstract RemoteTerminalEmulator<?> createRte(SutConnection conn, StatisticMgr statMgr,
+			long rteSleepTime);
 	
 	public abstract String getBenchmarkName();
 }

--- a/src/main/java/org/vanilladb/bench/StatisticMgr.java
+++ b/src/main/java/org/vanilladb/bench/StatisticMgr.java
@@ -168,7 +168,7 @@ public class StatisticMgr {
 		}
 
 		if (logger.isLoggable(Level.INFO))
-			logger.info("Finnish creating tpcc benchmark report");
+			logger.info("Finnish creating benchmark report");
 	}
 
 	private void outputDetailReport(String fileName) throws IOException {

--- a/src/main/java/org/vanilladb/bench/StatisticMgr.java
+++ b/src/main/java/org/vanilladb/bench/StatisticMgr.java
@@ -36,31 +36,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.vanilladb.bench.util.BenchProperties;
-
 public class StatisticMgr {
 	private static Logger logger = Logger.getLogger(StatisticMgr.class.getName());
-
-	private static final File OUTPUT_DIR;
-	private static int GRANULARITY;
-
-	static {
-		String outputDirPath = BenchProperties.getLoader()
-				.getPropertyAsString(StatisticMgr.class.getName() + ".OUTPUT_DIR", null);
-
-		if (outputDirPath == null) {
-			OUTPUT_DIR = new File(System.getProperty("user.home"), "benchmark_results");
-		} else {
-			OUTPUT_DIR = new File(outputDirPath);
-		}
-
-		// Create the directory if that doesn't exist
-		if (!OUTPUT_DIR.exists())
-			OUTPUT_DIR.mkdir();
-
-		GRANULARITY = BenchProperties.getLoader().getPropertyAsInteger(
-				StatisticMgr.class.getName() + ".GRANULARITY", 3000);
-	}
 
 	private static class TxnStatistic {
 		private BenchTransactionType mType;
@@ -100,6 +77,8 @@ public class StatisticMgr {
 		}
 	}
 	
+	private File outputDir;
+	private int timelineGranularity;
 	private BlockingQueue<TxnResultSet> resultSets = new ArrayBlockingQueue<TxnResultSet>(100_000);
 	private int totalTxnCount;
 	private double totalResTimeMs;
@@ -111,14 +90,12 @@ public class StatisticMgr {
 	private Map<BenchTransactionType, TxnStatistic> txnStatistics = new HashMap<BenchTransactionType, TxnStatistic>();
 	private Map<BenchTransactionType, Integer> abortedCounts = new HashMap<BenchTransactionType, Integer>();
 
-	public StatisticMgr(Collection<BenchTransactionType> txTypes) {
-		allTxTypes = new LinkedList<BenchTransactionType>(txTypes);
-		initZipThread();
-	}
-
-	public StatisticMgr(Collection<BenchTransactionType> txTypes, String namePostfix) {
-		allTxTypes = new LinkedList<BenchTransactionType>(txTypes);
-		fileNamePostfix = namePostfix;
+	public StatisticMgr(Collection<BenchTransactionType> txTypes, File outputDir,
+			String namePostfix, int timelineGranularity) {
+		this.allTxTypes = new LinkedList<BenchTransactionType>(txTypes);
+		this.outputDir = outputDir;
+		this.fileNamePostfix = namePostfix;
+		this.timelineGranularity = timelineGranularity;
 		initZipThread();
 	}
 	
@@ -139,7 +116,7 @@ public class StatisticMgr {
 			while (!stop||!resultSets.isEmpty()) {
 				try {
 					TxnResultSet resultSet = resultSets.poll(1, TimeUnit.SECONDS);
-					if (resultSet!=null) {
+					if (resultSet != null) {
 						analyzeResultSet(resultSet);
 					}
 				} catch (InterruptedException e) {
@@ -196,7 +173,7 @@ public class StatisticMgr {
 
 	private void outputDetailReport(String fileName) throws IOException {
 		try (BufferedWriter writer = new BufferedWriter(
-				new FileWriter(new File(OUTPUT_DIR, fileName + ".txt")))) {
+				new FileWriter(new File(outputDir, fileName + ".txt")))) {
 			// First line: total transaction count
 			writer.write("# of txns (including aborted) during benchmark period: " + totalTxnCount);
 			writer.newLine();
@@ -230,12 +207,12 @@ public class StatisticMgr {
 	}
 
 	private void outputTimelineReport(String fileName) throws IOException {
-		try (BufferedWriter writer = new BufferedWriter(new FileWriter(new File(OUTPUT_DIR, fileName + ".csv")))) {
+		try (BufferedWriter writer = new BufferedWriter(new FileWriter(new File(outputDir, fileName + ".csv")))) {
 			writer.write(
 					"time(sec), throughput(txs), avg_latency(ms), min(ms), max(ms), 25th_lat(ms), median_lat(ms), 75th_lat(ms)");
 			writer.newLine();
 
-			int timeAdvance = GRANULARITY / 1000;
+			int timeAdvance = timelineGranularity / 1000;
 			for (long timeBound = 0, outCount = 0; outCount < latencyHistory.size(); timeBound += timeAdvance) {
 				List<Long> slot = latencyHistory.get(timeBound);
 				if (slot != null) {
@@ -250,7 +227,8 @@ public class StatisticMgr {
 
 	private void analyzeResultSet(TxnResultSet rs) {
 		long elapsedTime = TimeUnit.NANOSECONDS.toMillis(rs.getTxnEndTime() - recordStartTime);
-		long timeSlotBoundary = (elapsedTime / GRANULARITY) * GRANULARITY / 1000; // in seconds
+		long timeSlotBoundary = 
+				(elapsedTime / timelineGranularity) * timelineGranularity / 1000; // in seconds
 
 		ArrayList<Long> timeSlot = latencyHistory.get(timeSlotBoundary);
 		if (timeSlot == null) {

--- a/src/main/java/org/vanilladb/bench/VanillaBenchParameters.java
+++ b/src/main/java/org/vanilladb/bench/VanillaBenchParameters.java
@@ -15,13 +15,14 @@
  *******************************************************************************/
 package org.vanilladb.bench;
 
+import java.io.File;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.vanilladb.bench.util.BenchProperties;
 
-public class BenchmarkerParameters {
-	private static Logger logger = Logger.getLogger(BenchmarkerParameters.class
+public class VanillaBenchParameters {
+	private static Logger logger = Logger.getLogger(VanillaBenchParameters.class
 			.getName());
 	
 	public static final long WARM_UP_INTERVAL;
@@ -40,26 +41,31 @@ public class BenchmarkerParameters {
 	public static final BenchType BENCH_TYPE;
 	
 	public static final boolean PROFILING_ON_SERVER;
+	
+	public static final File REPORT_OUTPUT_DIRECTORY;
+	public static final int REPORT_TIMELINE_GRANULARITY;
+	
+	public static final boolean SHOW_TXN_RESPONSE_ON_CONSOLE;
 
 	static {
 		WARM_UP_INTERVAL = BenchProperties.getLoader().getPropertyAsLong(
-				BenchmarkerParameters.class.getName() + ".WARM_UP_INTERVAL", 60000);
+				VanillaBenchParameters.class.getName() + ".WARM_UP_INTERVAL", 60000);
 
 		BENCHMARK_INTERVAL = BenchProperties.getLoader().getPropertyAsLong(
-				BenchmarkerParameters.class.getName() + ".BENCHMARK_INTERVAL",
+				VanillaBenchParameters.class.getName() + ".BENCHMARK_INTERVAL",
 				60000);
 
 		NUM_RTES = BenchProperties.getLoader().getPropertyAsInteger(
-				BenchmarkerParameters.class.getName() + ".NUM_RTES", 1);
+				VanillaBenchParameters.class.getName() + ".NUM_RTES", 1);
 		
 		RTE_SLEEP_TIME = BenchProperties.getLoader().getPropertyAsLong(
-				BenchmarkerParameters.class.getName() + ".RTE_SLEEP_TIME", 0);
+				VanillaBenchParameters.class.getName() + ".RTE_SLEEP_TIME", 0);
 		
 		SERVER_IP = BenchProperties.getLoader().getPropertyAsString(
-				BenchmarkerParameters.class.getName() + ".SERVER_IP", "127.0.0.1");
+				VanillaBenchParameters.class.getName() + ".SERVER_IP", "127.0.0.1");
 		
 		int conMode = BenchProperties.getLoader().getPropertyAsInteger(
-				BenchmarkerParameters.class.getName() + ".CONNECTION_MODE", 1);
+				VanillaBenchParameters.class.getName() + ".CONNECTION_MODE", 1);
 		switch (conMode) {
 		case 1:
 			CONNECTION_MODE = ConnectionMode.JDBC;
@@ -72,7 +78,7 @@ public class BenchmarkerParameters {
 		}
 
 		int benchType = BenchProperties.getLoader().getPropertyAsInteger(
-				BenchmarkerParameters.class.getName() + ".BENCH_TYPE", 1);
+				VanillaBenchParameters.class.getName() + ".BENCH_TYPE", 1);
 		switch (benchType) {
 		case 1:
 			BENCH_TYPE = BenchType.MICRO;
@@ -94,6 +100,27 @@ public class BenchmarkerParameters {
 			logger.info("Using " + BENCH_TYPE + " benchmarks");
 		
 		PROFILING_ON_SERVER = BenchProperties.getLoader().getPropertyAsBoolean(
-				BenchmarkerParameters.class.getName() + ".PROFILING_ON_SERVER", false);
+				VanillaBenchParameters.class.getName() + ".PROFILING_ON_SERVER", false);
+		
+		// Report Output Directory
+		String outputDirPath = BenchProperties.getLoader()
+				.getPropertyAsString(
+						VanillaBenchParameters.class.getName() + ".REPORT_OUTPUT_DIRECTORY",null);
+
+		if (outputDirPath == null) {
+			REPORT_OUTPUT_DIRECTORY = new File(System.getProperty("user.home"), "benchmark_results");
+		} else {
+			REPORT_OUTPUT_DIRECTORY = new File(outputDirPath);
+		}
+
+		// Create the directory if that doesn't exist
+		if (!REPORT_OUTPUT_DIRECTORY.exists())
+			REPORT_OUTPUT_DIRECTORY.mkdir();
+
+		REPORT_TIMELINE_GRANULARITY = BenchProperties.getLoader().getPropertyAsInteger(
+				VanillaBenchParameters.class.getName() + ".REPORT_TIMELINE_GRANULARITY", 3000);
+		
+		SHOW_TXN_RESPONSE_ON_CONSOLE = BenchProperties.getLoader().getPropertyAsBoolean(
+				VanillaBenchParameters.class.getName() + ".SHOW_TXN_RESPONSE_ON_CONSOLE", false);
 	}
 }

--- a/src/main/java/org/vanilladb/bench/benchmarks/micro/MicroBenchmark.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/micro/MicroBenchmark.java
@@ -22,7 +22,7 @@ import java.util.Set;
 
 import org.vanilladb.bench.BenchTransactionType;
 import org.vanilladb.bench.Benchmark;
-import org.vanilladb.bench.BenchmarkerParameters;
+import org.vanilladb.bench.VanillaBenchParameters;
 import org.vanilladb.bench.StatisticMgr;
 import org.vanilladb.bench.benchmarks.micro.rte.MicrobenchmarkRte;
 import org.vanilladb.bench.benchmarks.micro.rte.jdbc.MicrobenchJdbcExecutor;
@@ -49,8 +49,9 @@ public class MicroBenchmark extends Benchmark {
 	}
 
 	@Override
-	public RemoteTerminalEmulator<MicrobenchTransactionType> createRte(SutConnection conn, StatisticMgr statMgr) {
-		return new MicrobenchmarkRte(conn, statMgr);
+	public RemoteTerminalEmulator<MicrobenchTransactionType> createRte(SutConnection conn, StatisticMgr statMgr,
+			long rteSleepTime) {
+		return new MicrobenchmarkRte(conn, statMgr, rteSleepTime);
 	}
 
 	@Override
@@ -59,7 +60,7 @@ public class MicroBenchmark extends Benchmark {
 		MicrobenchTransactionType txnType = MicrobenchTransactionType.CHECK_DATABASE;
 		Object[] params = new Object[] {MicrobenchConstants.NUM_ITEMS};
 		
-		switch (BenchmarkerParameters.CONNECTION_MODE) {
+		switch (VanillaBenchParameters.CONNECTION_MODE) {
 		case JDBC:
 			Connection jdbcConn = conn.toJdbcConnection();
 			jdbcConn.setAutoCommit(false);

--- a/src/main/java/org/vanilladb/bench/benchmarks/micro/rte/MicrobenchmarkRte.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/micro/rte/MicrobenchmarkRte.java
@@ -24,8 +24,9 @@ public class MicrobenchmarkRte extends RemoteTerminalEmulator<MicrobenchTransact
 	
 	private MicrobenchmarkTxExecutor executor;
 
-	public MicrobenchmarkRte(SutConnection conn, StatisticMgr statMgr) {
-		super(conn, statMgr);
+	public MicrobenchmarkRte(SutConnection conn, StatisticMgr statMgr,
+			long sleepTime) {
+		super(conn, statMgr, sleepTime);
 		executor = new MicrobenchmarkTxExecutor(new MicrobenchmarkParamGen());
 	}
 	

--- a/src/main/java/org/vanilladb/bench/benchmarks/micro/rte/MicrobenchmarkTxExecutor.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/micro/rte/MicrobenchmarkTxExecutor.java
@@ -16,6 +16,7 @@
 package org.vanilladb.bench.benchmarks.micro.rte;
 
 import org.vanilladb.bench.TxnResultSet;
+import org.vanilladb.bench.VanillaBenchParameters;
 import org.vanilladb.bench.benchmarks.micro.MicrobenchTransactionType;
 import org.vanilladb.bench.benchmarks.micro.rte.jdbc.MicrobenchJdbcExecutor;
 import org.vanilladb.bench.remote.SutConnection;
@@ -47,7 +48,7 @@ public class MicrobenchmarkTxExecutor extends TransactionExecutor<MicrobenchTran
 			txnRT = txnEndTime - txnRT;
 
 			// display output
-			if (TransactionExecutor.DISPLAY_RESULT)
+			if (VanillaBenchParameters.SHOW_TXN_RESPONSE_ON_CONSOLE)
 				System.out.println(pg.getTxnType() + " " + result.outputMsg());
 
 			return new TxnResultSet(pg.getTxnType(), txnRT, txnEndTime,

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpcc/TpccBenchmark.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpcc/TpccBenchmark.java
@@ -52,7 +52,7 @@ public class TpccBenchmark extends Benchmark {
 	public RemoteTerminalEmulator<TpccTransactionType> createRte(SutConnection conn, StatisticMgr statMgr,
 			long rteSleepTime) {
 		TpccRte rte = new TpccRte(conn, statMgr, rteSleepTime, nextWid + 1);
-		nextWid = (nextWid + 1) % TpccConstants.NUM_WAREHOUSES;
+		nextWid = (nextWid + 1) % TpccParameters.NUM_WAREHOUSES;
 		return rte;
 	}
 

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpcc/TpccBenchmark.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpcc/TpccBenchmark.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 import org.vanilladb.bench.BenchTransactionType;
 import org.vanilladb.bench.Benchmark;
-import org.vanilladb.bench.BenchmarkerParameters;
+import org.vanilladb.bench.VanillaBenchParameters;
 import org.vanilladb.bench.StatisticMgr;
 import org.vanilladb.bench.benchmarks.tpcc.rte.TpccRte;
 import org.vanilladb.bench.remote.SutConnection;
@@ -49,8 +49,9 @@ public class TpccBenchmark extends Benchmark {
 	}
 
 	@Override
-	public RemoteTerminalEmulator<TpccTransactionType> createRte(SutConnection conn, StatisticMgr statMgr) {
-		TpccRte rte = new TpccRte(conn, statMgr, nextWid + 1);
+	public RemoteTerminalEmulator<TpccTransactionType> createRte(SutConnection conn, StatisticMgr statMgr,
+			long rteSleepTime) {
+		TpccRte rte = new TpccRte(conn, statMgr, nextWid + 1, rteSleepTime);
 		nextWid = (nextWid + 1) % TpccConstants.NUM_WAREHOUSES;
 		return rte;
 	}
@@ -61,7 +62,7 @@ public class TpccBenchmark extends Benchmark {
 		TpccTransactionType txnType = TpccTransactionType.CHECK_DATABASE;
 		Object[] params = new Object[0];
 		
-		switch (BenchmarkerParameters.CONNECTION_MODE) {
+		switch (VanillaBenchParameters.CONNECTION_MODE) {
 		case JDBC:
 			throw new RuntimeException("We do not implement checking procedure for JDBC");
 		case SP:

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpcc/TpccBenchmark.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpcc/TpccBenchmark.java
@@ -51,7 +51,7 @@ public class TpccBenchmark extends Benchmark {
 	@Override
 	public RemoteTerminalEmulator<TpccTransactionType> createRte(SutConnection conn, StatisticMgr statMgr,
 			long rteSleepTime) {
-		TpccRte rte = new TpccRte(conn, statMgr, nextWid + 1, rteSleepTime);
+		TpccRte rte = new TpccRte(conn, statMgr, rteSleepTime, nextWid + 1);
 		nextWid = (nextWid + 1) % TpccConstants.NUM_WAREHOUSES;
 		return rte;
 	}

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpcc/TpccConstants.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpcc/TpccConstants.java
@@ -15,14 +15,10 @@
  *******************************************************************************/
 package org.vanilladb.bench.benchmarks.tpcc;
 
-import org.vanilladb.bench.util.BenchProperties;
-
 /** Holds TPC-C constants. */
 
 public class TpccConstants {
 
-	// Scaling parameters
-	public static final int NUM_WAREHOUSES;
 	public static final int NUM_ITEMS = 100000;
 	public static final int DISTRICTS_PER_WAREHOUSE = 10;
 	public static final int CUSTOMERS_PER_DISTRICT = 3000;
@@ -33,11 +29,6 @@ public class TpccConstants {
 	public static final int NEW_ORDERS_PER_DISTRICT = 3000;
 	public static final int NEW_ORDER_START_ID = (int) (NEW_ORDERS_PER_DISTRICT * ((double) 2101 / 3000));
 	public static final int NUM_DISTINCT_CLAST = (int) NEW_ORDERS_PER_DISTRICT / 3;
-
-	static {
-		NUM_WAREHOUSES = BenchProperties.getLoader().getPropertyAsInteger(
-				TpccConstants.class.getName() + ".NUM_WAREHOUSES", 1);
-	}
 
 	// 9 tables's names
 	public static final String TABLENAME_WAREHOUSE = "warehouse";
@@ -53,38 +44,6 @@ public class TpccConstants {
 			TABLENAME_DISTRICT, TABLENAME_ITEM, TABLENAME_CUSTOMER,
 			TABLENAME_HISTORY, TABLENAME_STOCK, TABLENAME_ORDERS,
 			TABLENAME_NEW_ORDER, TABLENAME_ORDER_LINE, };
-
-	// Transaction frequency follows the mixture requirement
-	public static final int FREQUENCY_TOTAL;
-	public static final int FREQUENCY_NEW_ORDER;
-	public static final int FREQUENCY_PAYMENT;
-	public static final int FREQUENCY_ORDER_STATUS;
-	public static final int FREQUENCY_DELIVERY;
-	public static final int FREQUENCY_STOCK_LEVEL;
-	static {
-		FREQUENCY_TOTAL = BenchProperties.getLoader().getPropertyAsInteger(
-				TpccConstants.class.getName() + ".FREQUENCY_TOTAL", 100);
-		FREQUENCY_NEW_ORDER = BenchProperties.getLoader().getPropertyAsInteger(
-				TpccConstants.class.getName() + ".FREQUENCY_NEW_ORDER", 45);
-		FREQUENCY_PAYMENT = BenchProperties.getLoader().getPropertyAsInteger(
-				TpccConstants.class.getName() + ".FREQUENCY_PAYMENT", 43);
-		FREQUENCY_ORDER_STATUS = BenchProperties.getLoader().getPropertyAsInteger(
-				TpccConstants.class.getName() + ".FREQUENCY_ORDER_STATUS", 4);
-		FREQUENCY_DELIVERY = BenchProperties.getLoader().getPropertyAsInteger(
-				TpccConstants.class.getName() + ".FREQUENCY_DELIVERY", 4);
-		FREQUENCY_STOCK_LEVEL = BenchProperties.getLoader().getPropertyAsInteger(
-				TpccConstants.class.getName() + ".FREQUENCY_STOCK_LEVEL", 4);
-	}
-
-	// Range for uniformly selecting transaction type
-	public static final int RANGE_NEW_ORDER = FREQUENCY_NEW_ORDER;
-	public static final int RANGE_PAYMENT = RANGE_NEW_ORDER + FREQUENCY_PAYMENT;
-	public static final int RANGE_ORDER_STATUS = RANGE_PAYMENT
-			+ FREQUENCY_ORDER_STATUS;
-	public static final int RANGE_DELIVERY = RANGE_ORDER_STATUS
-			+ FREQUENCY_DELIVERY;
-	public static final int RANGE_STOCK_LEVEL = RANGE_DELIVERY
-			+ FREQUENCY_STOCK_LEVEL;
 
 	// Minimal keying time in second
 	public static final int KEYING_NEW_ORDER = 18;

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpcc/TpccParameters.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpcc/TpccParameters.java
@@ -1,0 +1,52 @@
+package org.vanilladb.bench.benchmarks.tpcc;
+
+import org.vanilladb.bench.benchmarks.tpcc.rte.TpccTxExecutor;
+import org.vanilladb.bench.util.BenchProperties;
+
+public class TpccParameters {
+
+	// Scaling parameters
+	public static final int NUM_WAREHOUSES;
+	
+	public static final boolean ENABLE_THINK_AND_KEYING_TIME;
+
+	// Transaction frequency follows the mixture requirement
+	public static final int FREQUENCY_TOTAL;
+	public static final int FREQUENCY_NEW_ORDER;
+	public static final int FREQUENCY_PAYMENT;
+	public static final int FREQUENCY_ORDER_STATUS;
+	public static final int FREQUENCY_DELIVERY;
+	public static final int FREQUENCY_STOCK_LEVEL;
+	
+	static {
+		NUM_WAREHOUSES = BenchProperties.getLoader().getPropertyAsInteger(
+				TpccConstants.class.getName() + ".NUM_WAREHOUSES", 1);
+		
+		ENABLE_THINK_AND_KEYING_TIME = BenchProperties.getLoader()
+				.getPropertyAsBoolean(TpccTxExecutor.class.getName() +
+						".ENABLE_THINK_AND_KEYING_TIME", false);
+		
+		FREQUENCY_TOTAL = BenchProperties.getLoader().getPropertyAsInteger(
+				TpccConstants.class.getName() + ".FREQUENCY_TOTAL", 100);
+		FREQUENCY_NEW_ORDER = BenchProperties.getLoader().getPropertyAsInteger(
+				TpccConstants.class.getName() + ".FREQUENCY_NEW_ORDER", 45);
+		FREQUENCY_PAYMENT = BenchProperties.getLoader().getPropertyAsInteger(
+				TpccConstants.class.getName() + ".FREQUENCY_PAYMENT", 43);
+		FREQUENCY_ORDER_STATUS = BenchProperties.getLoader().getPropertyAsInteger(
+				TpccConstants.class.getName() + ".FREQUENCY_ORDER_STATUS", 4);
+		FREQUENCY_DELIVERY = BenchProperties.getLoader().getPropertyAsInteger(
+				TpccConstants.class.getName() + ".FREQUENCY_DELIVERY", 4);
+		FREQUENCY_STOCK_LEVEL = BenchProperties.getLoader().getPropertyAsInteger(
+				TpccConstants.class.getName() + ".FREQUENCY_STOCK_LEVEL", 4);
+	}
+
+	// Range for uniformly selecting transaction type
+	public static final int RANGE_NEW_ORDER = FREQUENCY_NEW_ORDER;
+	public static final int RANGE_PAYMENT = RANGE_NEW_ORDER + FREQUENCY_PAYMENT;
+	public static final int RANGE_ORDER_STATUS = RANGE_PAYMENT
+			+ FREQUENCY_ORDER_STATUS;
+	public static final int RANGE_DELIVERY = RANGE_ORDER_STATUS
+			+ FREQUENCY_DELIVERY;
+	public static final int RANGE_STOCK_LEVEL = RANGE_DELIVERY
+			+ FREQUENCY_STOCK_LEVEL;
+}

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpcc/TpccParameters.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpcc/TpccParameters.java
@@ -1,6 +1,5 @@
 package org.vanilladb.bench.benchmarks.tpcc;
 
-import org.vanilladb.bench.benchmarks.tpcc.rte.TpccTxExecutor;
 import org.vanilladb.bench.util.BenchProperties;
 
 public class TpccParameters {
@@ -20,24 +19,24 @@ public class TpccParameters {
 	
 	static {
 		NUM_WAREHOUSES = BenchProperties.getLoader().getPropertyAsInteger(
-				TpccConstants.class.getName() + ".NUM_WAREHOUSES", 1);
+				TpccParameters.class.getName() + ".NUM_WAREHOUSES", 1);
 		
 		ENABLE_THINK_AND_KEYING_TIME = BenchProperties.getLoader()
-				.getPropertyAsBoolean(TpccTxExecutor.class.getName() +
+				.getPropertyAsBoolean(TpccParameters.class.getName() +
 						".ENABLE_THINK_AND_KEYING_TIME", false);
 		
 		FREQUENCY_TOTAL = BenchProperties.getLoader().getPropertyAsInteger(
-				TpccConstants.class.getName() + ".FREQUENCY_TOTAL", 100);
+				TpccParameters.class.getName() + ".FREQUENCY_TOTAL", 100);
 		FREQUENCY_NEW_ORDER = BenchProperties.getLoader().getPropertyAsInteger(
-				TpccConstants.class.getName() + ".FREQUENCY_NEW_ORDER", 45);
+				TpccParameters.class.getName() + ".FREQUENCY_NEW_ORDER", 45);
 		FREQUENCY_PAYMENT = BenchProperties.getLoader().getPropertyAsInteger(
-				TpccConstants.class.getName() + ".FREQUENCY_PAYMENT", 43);
+				TpccParameters.class.getName() + ".FREQUENCY_PAYMENT", 43);
 		FREQUENCY_ORDER_STATUS = BenchProperties.getLoader().getPropertyAsInteger(
-				TpccConstants.class.getName() + ".FREQUENCY_ORDER_STATUS", 4);
+				TpccParameters.class.getName() + ".FREQUENCY_ORDER_STATUS", 4);
 		FREQUENCY_DELIVERY = BenchProperties.getLoader().getPropertyAsInteger(
-				TpccConstants.class.getName() + ".FREQUENCY_DELIVERY", 4);
+				TpccParameters.class.getName() + ".FREQUENCY_DELIVERY", 4);
 		FREQUENCY_STOCK_LEVEL = BenchProperties.getLoader().getPropertyAsInteger(
-				TpccConstants.class.getName() + ".FREQUENCY_STOCK_LEVEL", 4);
+				TpccParameters.class.getName() + ".FREQUENCY_STOCK_LEVEL", 4);
 	}
 
 	// Range for uniformly selecting transaction type

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpcc/rte/NewOrderParamGen.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpcc/rte/NewOrderParamGen.java
@@ -16,6 +16,7 @@
 package org.vanilladb.bench.benchmarks.tpcc.rte;
 
 import org.vanilladb.bench.benchmarks.tpcc.TpccConstants;
+import org.vanilladb.bench.benchmarks.tpcc.TpccParameters;
 import org.vanilladb.bench.benchmarks.tpcc.TpccTransactionType;
 import org.vanilladb.bench.benchmarks.tpcc.TpccValueGenerator;
 
@@ -69,8 +70,8 @@ public class NewOrderParamGen implements TpccTxParamGenerator {
 
 			// TODO: Verify this
 			// ol_supply_w_id. 1% of items are supplied by remote warehouse
-			if (valueGen.rng().nextDouble() < 0.05 && TpccConstants.NUM_WAREHOUSES > 1) {
-				pars[++j] = valueGen.numberExcluding(1, TpccConstants.NUM_WAREHOUSES, homeWid);
+			if (valueGen.rng().nextDouble() < 0.05 && TpccParameters.NUM_WAREHOUSES > 1) {
+				pars[++j] = valueGen.numberExcluding(1, TpccParameters.NUM_WAREHOUSES, homeWid);
 				allLocal = false;
 			} else
 				pars[++j] = homeWid;

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpcc/rte/PaymentParamGen.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpcc/rte/PaymentParamGen.java
@@ -16,6 +16,7 @@
 package org.vanilladb.bench.benchmarks.tpcc.rte;
 
 import org.vanilladb.bench.benchmarks.tpcc.TpccConstants;
+import org.vanilladb.bench.benchmarks.tpcc.TpccParameters;
 import org.vanilladb.bench.benchmarks.tpcc.TpccTransactionType;
 import org.vanilladb.bench.benchmarks.tpcc.TpccValueGenerator;
 
@@ -48,8 +49,8 @@ public class PaymentParamGen implements TpccTxParamGenerator {
 		 * Customer resident warehouse is the home warehouse 85% of the time and
 		 * is a randomly selected remote warehouse 15% of the time.
 		 */
-		if (valueGen.rng().nextDouble() >= 0.85 && TpccConstants.NUM_WAREHOUSES > 1) {
-			pars[2] = valueGen.numberExcluding(1, TpccConstants.NUM_WAREHOUSES, homeWid);
+		if (valueGen.rng().nextDouble() >= 0.85 && TpccParameters.NUM_WAREHOUSES > 1) {
+			pars[2] = valueGen.numberExcluding(1, TpccParameters.NUM_WAREHOUSES, homeWid);
 			pars[3] = valueGen.number(1, 10);
 		} else {
 			pars[2] = homeWid;

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpcc/rte/TpccRte.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpcc/rte/TpccRte.java
@@ -33,8 +33,8 @@ public class TpccRte extends RemoteTerminalEmulator<TpccTransactionType> {
 	private int homeWid;
 	private Map<BenchTransactionType, TpccTxExecutor> executors;
 
-	public TpccRte(SutConnection conn, StatisticMgr statMgr, int homeWarehouseId,
-			long sleepTime) {
+	public TpccRte(SutConnection conn, StatisticMgr statMgr, long sleepTime,
+			int homeWarehouseId) {
 		super(conn, statMgr, sleepTime);
 		homeWid = homeWarehouseId;
 		executors = new HashMap<BenchTransactionType, TpccTxExecutor>();

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpcc/rte/TpccRte.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpcc/rte/TpccRte.java
@@ -19,8 +19,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 
-import org.vanilladb.bench.StatisticMgr;
 import org.vanilladb.bench.BenchTransactionType;
+import org.vanilladb.bench.StatisticMgr;
 import org.vanilladb.bench.benchmarks.tpcc.TpccConstants;
 import org.vanilladb.bench.benchmarks.tpcc.TpccTransactionType;
 import org.vanilladb.bench.remote.SutConnection;
@@ -33,8 +33,9 @@ public class TpccRte extends RemoteTerminalEmulator<TpccTransactionType> {
 	private int homeWid;
 	private Map<BenchTransactionType, TpccTxExecutor> executors;
 
-	public TpccRte(SutConnection conn, StatisticMgr statMgr, int homeWarehouseId) {
-		super(conn, statMgr);
+	public TpccRte(SutConnection conn, StatisticMgr statMgr, int homeWarehouseId,
+			long sleepTime) {
+		super(conn, statMgr, sleepTime);
 		homeWid = homeWarehouseId;
 		executors = new HashMap<BenchTransactionType, TpccTxExecutor>();
 		executors.put(TpccTransactionType.NEW_ORDER, new TpccTxExecutor(new NewOrderParamGen(homeWid)));

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpcc/rte/TpccRte.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpcc/rte/TpccRte.java
@@ -21,7 +21,7 @@ import java.util.Random;
 
 import org.vanilladb.bench.BenchTransactionType;
 import org.vanilladb.bench.StatisticMgr;
-import org.vanilladb.bench.benchmarks.tpcc.TpccConstants;
+import org.vanilladb.bench.benchmarks.tpcc.TpccParameters;
 import org.vanilladb.bench.benchmarks.tpcc.TpccTransactionType;
 import org.vanilladb.bench.remote.SutConnection;
 import org.vanilladb.bench.rte.RemoteTerminalEmulator;
@@ -46,14 +46,14 @@ public class TpccRte extends RemoteTerminalEmulator<TpccTransactionType> {
 	}
 	
 	protected TpccTransactionType getNextTxType() {
-		int index = TX_TYPE_RANDOM.nextInt(TpccConstants.FREQUENCY_TOTAL);
-		if (index < TpccConstants.RANGE_NEW_ORDER)
+		int index = TX_TYPE_RANDOM.nextInt(TpccParameters.FREQUENCY_TOTAL);
+		if (index < TpccParameters.RANGE_NEW_ORDER)
 			return TpccTransactionType.NEW_ORDER;
-		else if (index < TpccConstants.RANGE_PAYMENT)
+		else if (index < TpccParameters.RANGE_PAYMENT)
 			return TpccTransactionType.PAYMENT;
-		else if (index < TpccConstants.RANGE_ORDER_STATUS)
+		else if (index < TpccParameters.RANGE_ORDER_STATUS)
 			return TpccTransactionType.ORDER_STATUS;
-		else if (index < TpccConstants.RANGE_DELIVERY)
+		else if (index < TpccParameters.RANGE_DELIVERY)
 			return TpccTransactionType.DELIVERY;
 		else
 			return TpccTransactionType.STOCK_LEVEL;

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpcc/rte/TpccTxExecutor.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpcc/rte/TpccTxExecutor.java
@@ -17,21 +17,14 @@ package org.vanilladb.bench.benchmarks.tpcc.rte;
 
 import org.vanilladb.bench.TxnResultSet;
 import org.vanilladb.bench.VanillaBenchParameters;
+import org.vanilladb.bench.benchmarks.tpcc.TpccParameters;
 import org.vanilladb.bench.benchmarks.tpcc.TpccTransactionType;
 import org.vanilladb.bench.remote.SutConnection;
 import org.vanilladb.bench.remote.SutResultSet;
 import org.vanilladb.bench.rte.TransactionExecutor;
 import org.vanilladb.bench.rte.jdbc.JdbcExecutor;
-import org.vanilladb.bench.util.BenchProperties;
 
 public class TpccTxExecutor extends TransactionExecutor<TpccTransactionType> {
-
-	private final static boolean ENABLE_THINK_AND_KEYING_TIME;
-
-	static {
-		ENABLE_THINK_AND_KEYING_TIME = BenchProperties.getLoader()
-				.getPropertyAsBoolean(TpccTxExecutor.class.getName() + ".ENABLE_THINK_AND_KEYING_TIME", false);
-	}
 	
 	private TpccTxParamGenerator tpccPg;
 
@@ -44,7 +37,7 @@ public class TpccTxExecutor extends TransactionExecutor<TpccTransactionType> {
 	public TxnResultSet execute(SutConnection conn) {
 		try {
 			// keying
-			if (ENABLE_THINK_AND_KEYING_TIME) {
+			if (TpccParameters.ENABLE_THINK_AND_KEYING_TIME) {
 				// wait for a keying time and generate parameters
 				long t = tpccPg.getKeyingTime();
 				Thread.sleep(t);
@@ -67,7 +60,7 @@ public class TpccTxExecutor extends TransactionExecutor<TpccTransactionType> {
 				System.out.println(pg.getTxnType() + " " + result.outputMsg());
 
 			// thinking
-			if (ENABLE_THINK_AND_KEYING_TIME) {
+			if (TpccParameters.ENABLE_THINK_AND_KEYING_TIME) {
 				// wait for a think time
 				long t = tpccPg.getThinkTime();
 				Thread.sleep(t);

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpcc/rte/TpccTxExecutor.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpcc/rte/TpccTxExecutor.java
@@ -16,6 +16,7 @@
 package org.vanilladb.bench.benchmarks.tpcc.rte;
 
 import org.vanilladb.bench.TxnResultSet;
+import org.vanilladb.bench.VanillaBenchParameters;
 import org.vanilladb.bench.benchmarks.tpcc.TpccTransactionType;
 import org.vanilladb.bench.remote.SutConnection;
 import org.vanilladb.bench.remote.SutResultSet;
@@ -62,7 +63,7 @@ public class TpccTxExecutor extends TransactionExecutor<TpccTransactionType> {
 			txnRT = txnEndTime - txnRT;
 
 			// display output
-			if (TransactionExecutor.DISPLAY_RESULT)
+			if (VanillaBenchParameters.SHOW_TXN_RESPONSE_ON_CONSOLE)
 				System.out.println(pg.getTxnType() + " " + result.outputMsg());
 
 			// thinking

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpce/TpceBenchmark.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpce/TpceBenchmark.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 import org.vanilladb.bench.BenchTransactionType;
 import org.vanilladb.bench.Benchmark;
-import org.vanilladb.bench.BenchmarkerParameters;
+import org.vanilladb.bench.VanillaBenchParameters;
 import org.vanilladb.bench.StatisticMgr;
 import org.vanilladb.bench.benchmarks.tpce.data.TpceDataManager;
 import org.vanilladb.bench.benchmarks.tpce.rte.TpceRte;
@@ -50,8 +50,9 @@ public class TpceBenchmark extends Benchmark {
 	}
 
 	@Override
-	public RemoteTerminalEmulator<TpceTransactionType> createRte(SutConnection conn, StatisticMgr statMgr) {
-		return new TpceRte(conn, statMgr, dataMgr);
+	public RemoteTerminalEmulator<TpceTransactionType> createRte(SutConnection conn, StatisticMgr statMgr,
+			long rteSleepTime) {
+		return new TpceRte(conn, statMgr, dataMgr, rteSleepTime);
 	}
 
 	@Override
@@ -60,7 +61,7 @@ public class TpceBenchmark extends Benchmark {
 		TpceTransactionType txnType = TpceTransactionType.CHECK_DATABASE;
 		Object[] params = new Object[0];
 		
-		switch (BenchmarkerParameters.CONNECTION_MODE) {
+		switch (VanillaBenchParameters.CONNECTION_MODE) {
 		case JDBC:
 			throw new RuntimeException("We do not implement checking procedure for JDBC");
 		case SP:

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpce/TpceBenchmark.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpce/TpceBenchmark.java
@@ -52,7 +52,7 @@ public class TpceBenchmark extends Benchmark {
 	@Override
 	public RemoteTerminalEmulator<TpceTransactionType> createRte(SutConnection conn, StatisticMgr statMgr,
 			long rteSleepTime) {
-		return new TpceRte(conn, statMgr, dataMgr, rteSleepTime);
+		return new TpceRte(conn, statMgr, rteSleepTime, dataMgr);
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpce/rte/TpceRte.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpce/rte/TpceRte.java
@@ -30,8 +30,8 @@ public class TpceRte extends RemoteTerminalEmulator<TpceTransactionType> {
 	
 	private TpceDataManager dataMgr;
 	
-	public TpceRte(SutConnection conn, StatisticMgr statMgr, TpceDataManager dataMgr,
-			long sleepTime) {
+	public TpceRte(SutConnection conn, StatisticMgr statMgr, long sleepTime, 
+			TpceDataManager dataMgr) {
 		super(conn, statMgr, sleepTime);
 		this.dataMgr = dataMgr;
 	}

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpce/rte/TpceRte.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpce/rte/TpceRte.java
@@ -30,8 +30,9 @@ public class TpceRte extends RemoteTerminalEmulator<TpceTransactionType> {
 	
 	private TpceDataManager dataMgr;
 	
-	public TpceRte(SutConnection conn, StatisticMgr statMgr, TpceDataManager dataMgr) {
-		super(conn, statMgr);
+	public TpceRte(SutConnection conn, StatisticMgr statMgr, TpceDataManager dataMgr,
+			long sleepTime) {
+		super(conn, statMgr, sleepTime);
 		this.dataMgr = dataMgr;
 	}
 

--- a/src/main/java/org/vanilladb/bench/benchmarks/tpce/rte/TpceTxExecutor.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/tpce/rte/TpceTxExecutor.java
@@ -16,6 +16,7 @@
 package org.vanilladb.bench.benchmarks.tpce.rte;
 
 import org.vanilladb.bench.TxnResultSet;
+import org.vanilladb.bench.VanillaBenchParameters;
 import org.vanilladb.bench.benchmarks.tpce.TpceTransactionType;
 import org.vanilladb.bench.remote.SutConnection;
 import org.vanilladb.bench.remote.SutResultSet;
@@ -50,7 +51,7 @@ public class TpceTxExecutor extends TransactionExecutor<TpceTransactionType> {
 			paramGen.onResponseReceived(result);
 
 			// display output
-			if (TransactionExecutor.DISPLAY_RESULT)
+			if (VanillaBenchParameters.SHOW_TXN_RESPONSE_ON_CONSOLE)
 				System.out.println(pg.getTxnType() + " " + result.outputMsg());
 
 			return new TxnResultSet(pg.getTxnType(), txnRT, txnEndTime,

--- a/src/main/java/org/vanilladb/bench/benchmarks/ycsb/YcsbBenchmark.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/ycsb/YcsbBenchmark.java
@@ -6,7 +6,7 @@ import java.util.Set;
 
 import org.vanilladb.bench.BenchTransactionType;
 import org.vanilladb.bench.Benchmark;
-import org.vanilladb.bench.BenchmarkerParameters;
+import org.vanilladb.bench.VanillaBenchParameters;
 import org.vanilladb.bench.StatisticMgr;
 import org.vanilladb.bench.benchmarks.ycsb.rte.YcsbRte;
 import org.vanilladb.bench.remote.SutConnection;
@@ -32,8 +32,9 @@ public class YcsbBenchmark extends Benchmark {
 	}
 
 	@Override
-	public RemoteTerminalEmulator<YcsbTransactionType> createRte(SutConnection conn, StatisticMgr statMgr) {
-		return new YcsbRte(conn, statMgr);
+	public RemoteTerminalEmulator<YcsbTransactionType> createRte(SutConnection conn, StatisticMgr statMgr,
+			long rteSleepTime) {
+		return new YcsbRte(conn, statMgr, rteSleepTime);
 	}
 
 	@Override
@@ -42,7 +43,7 @@ public class YcsbBenchmark extends Benchmark {
 		YcsbTransactionType txnType = YcsbTransactionType.CHECK_DATABASE;
 		Object[] params = new Object[0];
 		
-		switch (BenchmarkerParameters.CONNECTION_MODE) {
+		switch (VanillaBenchParameters.CONNECTION_MODE) {
 		case JDBC:
 			throw new RuntimeException("We do not implement checking procedure for JDBC");
 		case SP:

--- a/src/main/java/org/vanilladb/bench/benchmarks/ycsb/rte/YcsbRte.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/ycsb/rte/YcsbRte.java
@@ -10,8 +10,7 @@ public class YcsbRte extends RemoteTerminalEmulator<YcsbTransactionType> {
 	
 	private YcsbTxExecutor executor;
 	
-	public YcsbRte(SutConnection conn, StatisticMgr statMgr,
-			long sleepTime) {
+	public YcsbRte(SutConnection conn, StatisticMgr statMgr, long sleepTime) {
 		super(conn, statMgr, sleepTime);
 		executor = new YcsbTxExecutor(new YcsbParamGen());
 	}

--- a/src/main/java/org/vanilladb/bench/benchmarks/ycsb/rte/YcsbRte.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/ycsb/rte/YcsbRte.java
@@ -10,8 +10,9 @@ public class YcsbRte extends RemoteTerminalEmulator<YcsbTransactionType> {
 	
 	private YcsbTxExecutor executor;
 	
-	public YcsbRte(SutConnection conn, StatisticMgr statMgr) {
-		super(conn, statMgr);
+	public YcsbRte(SutConnection conn, StatisticMgr statMgr,
+			long sleepTime) {
+		super(conn, statMgr, sleepTime);
 		executor = new YcsbTxExecutor(new YcsbParamGen());
 	}
 	

--- a/src/main/java/org/vanilladb/bench/benchmarks/ycsb/rte/YcsbTxExecutor.java
+++ b/src/main/java/org/vanilladb/bench/benchmarks/ycsb/rte/YcsbTxExecutor.java
@@ -1,6 +1,7 @@
 package org.vanilladb.bench.benchmarks.ycsb.rte;
 
 import org.vanilladb.bench.TxnResultSet;
+import org.vanilladb.bench.VanillaBenchParameters;
 import org.vanilladb.bench.benchmarks.ycsb.YcsbTransactionType;
 import org.vanilladb.bench.remote.SutConnection;
 import org.vanilladb.bench.remote.SutResultSet;
@@ -29,7 +30,7 @@ public class YcsbTxExecutor extends TransactionExecutor<YcsbTransactionType> {
 			txnRT = txnEndTime - txnRT;
 
 			// display output
-			if (TransactionExecutor.DISPLAY_RESULT)
+			if (VanillaBenchParameters.SHOW_TXN_RESPONSE_ON_CONSOLE)
 				System.out.println(pg.getTxnType() + " " + result.outputMsg());
 
 			return new TxnResultSet(pg.getTxnType(), txnRT, txnEndTime,

--- a/src/main/java/org/vanilladb/bench/remote/jdbc/VanillaDbJdbcDriver.java
+++ b/src/main/java/org/vanilladb/bench/remote/jdbc/VanillaDbJdbcDriver.java
@@ -18,14 +18,14 @@ package org.vanilladb.bench.remote.jdbc;
 import java.sql.Driver;
 import java.sql.SQLException;
 
-import org.vanilladb.bench.BenchmarkerParameters;
+import org.vanilladb.bench.VanillaBenchParameters;
 import org.vanilladb.bench.remote.SutConnection;
 import org.vanilladb.bench.remote.SutDriver;
 import org.vanilladb.core.remote.jdbc.JdbcDriver;
 
 public class VanillaDbJdbcDriver implements SutDriver {
 	
-	private static final String URL = "jdbc:vanilladb://" + BenchmarkerParameters.SERVER_IP;
+	private static final String URL = "jdbc:vanilladb://" + VanillaBenchParameters.SERVER_IP;
 	
 	private Driver driver;
 	

--- a/src/main/java/org/vanilladb/bench/remote/sp/VanillaDbSpDriver.java
+++ b/src/main/java/org/vanilladb/bench/remote/sp/VanillaDbSpDriver.java
@@ -17,7 +17,7 @@ package org.vanilladb.bench.remote.sp;
 
 import java.sql.SQLException;
 
-import org.vanilladb.bench.BenchmarkerParameters;
+import org.vanilladb.bench.VanillaBenchParameters;
 import org.vanilladb.bench.remote.SutConnection;
 import org.vanilladb.bench.remote.SutDriver;
 import org.vanilladb.core.remote.storedprocedure.SpDriver;
@@ -27,6 +27,6 @@ public class VanillaDbSpDriver implements SutDriver {
 	@Override
 	public SutConnection connectToSut() throws SQLException {
 		SpDriver driver = new SpDriver();
-		return new VanillaDbSpConnection(driver.connect(BenchmarkerParameters.SERVER_IP, null));
+		return new VanillaDbSpConnection(driver.connect(VanillaBenchParameters.SERVER_IP, null));
 	}
 }

--- a/src/main/java/org/vanilladb/bench/rte/RemoteTerminalEmulator.java
+++ b/src/main/java/org/vanilladb/bench/rte/RemoteTerminalEmulator.java
@@ -17,9 +17,8 @@ package org.vanilladb.bench.rte;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.vanilladb.bench.StatisticMgr;
 import org.vanilladb.bench.BenchTransactionType;
-import org.vanilladb.bench.BenchmarkerParameters;
+import org.vanilladb.bench.StatisticMgr;
 import org.vanilladb.bench.TxnResultSet;
 import org.vanilladb.bench.remote.SutConnection;
 
@@ -31,10 +30,13 @@ public abstract class RemoteTerminalEmulator<T extends BenchTransactionType> ext
 	private volatile boolean isWarmingUp = true;
 	private SutConnection conn;
 	private StatisticMgr statMgr;
+	private long sleepTime;
 	
-	public RemoteTerminalEmulator(SutConnection conn, StatisticMgr statMgr) {
+	public RemoteTerminalEmulator(SutConnection conn, StatisticMgr statMgr,
+			long sleepTime) {
 		this.conn = conn;
 		this.statMgr = statMgr;
+		this.sleepTime = sleepTime;
 		
 		// Set the thread name
 		setName("RTE-" + rteCount.getAndIncrement());
@@ -48,9 +50,9 @@ public abstract class RemoteTerminalEmulator<T extends BenchTransactionType> ext
 				statMgr.processTxnResult(rs);
 			
 			// Sleep for a while
-			if (BenchmarkerParameters.RTE_SLEEP_TIME > 0) {
+			if (sleepTime > 0) {
 				try {
-					Thread.sleep(BenchmarkerParameters.RTE_SLEEP_TIME);
+					Thread.sleep(sleepTime);
 				} catch (InterruptedException e) {
 					e.printStackTrace();
 					throw new RuntimeException(e);

--- a/src/main/java/org/vanilladb/bench/rte/RemoteTerminalEmulator.java
+++ b/src/main/java/org/vanilladb/bench/rte/RemoteTerminalEmulator.java
@@ -25,7 +25,9 @@ import org.vanilladb.bench.remote.SutConnection;
 public abstract class RemoteTerminalEmulator<T extends BenchTransactionType> extends Thread {
 
 	private static AtomicInteger rteCount = new AtomicInteger(0);
-
+	
+	protected int rteId;
+	
 	private volatile boolean stopBenchmark;
 	private volatile boolean isWarmingUp = true;
 	private SutConnection conn;
@@ -39,7 +41,8 @@ public abstract class RemoteTerminalEmulator<T extends BenchTransactionType> ext
 		this.sleepTime = sleepTime;
 		
 		// Set the thread name
-		setName("RTE-" + rteCount.getAndIncrement());
+		rteId = rteCount.getAndIncrement();
+		setName("RTE-" + rteId);
 	}
 
 	@Override
@@ -50,14 +53,7 @@ public abstract class RemoteTerminalEmulator<T extends BenchTransactionType> ext
 				statMgr.processTxnResult(rs);
 			
 			// Sleep for a while
-			if (sleepTime > 0) {
-				try {
-					Thread.sleep(sleepTime);
-				} catch (InterruptedException e) {
-					e.printStackTrace();
-					throw new RuntimeException(e);
-				}
-			}
+			sleep();
 		}
 	}
 
@@ -73,7 +69,18 @@ public abstract class RemoteTerminalEmulator<T extends BenchTransactionType> ext
 	protected abstract T getNextTxType();
 	
 	protected abstract TransactionExecutor<T> getTxExeutor(T type);
-
+	
+	protected void sleep() {		
+		if (sleepTime > 0) {
+			try {
+				Thread.sleep(sleepTime);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+				throw new RuntimeException(e);
+			}
+		}
+	}
+	
 	private TxnResultSet executeTxnCycle(SutConnection conn) {
 		T txType = getNextTxType();
 		TransactionExecutor<T> executor = getTxExeutor(txType);

--- a/src/main/java/org/vanilladb/bench/rte/TransactionExecutor.java
+++ b/src/main/java/org/vanilladb/bench/rte/TransactionExecutor.java
@@ -18,22 +18,14 @@ package org.vanilladb.bench.rte;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import org.vanilladb.bench.BenchmarkerParameters;
 import org.vanilladb.bench.BenchTransactionType;
 import org.vanilladb.bench.TxnResultSet;
+import org.vanilladb.bench.VanillaBenchParameters;
 import org.vanilladb.bench.remote.SutConnection;
 import org.vanilladb.bench.remote.SutResultSet;
 import org.vanilladb.bench.rte.jdbc.JdbcExecutor;
-import org.vanilladb.bench.util.BenchProperties;
 
 public abstract class TransactionExecutor<T extends BenchTransactionType> {
-
-	public static final boolean DISPLAY_RESULT;
-
-	static {
-		DISPLAY_RESULT = BenchProperties.getLoader()
-				.getPropertyAsBoolean(TransactionExecutor.class.getName() + ".DISPLAY_RESULT", false);
-	}
 
 	protected TxParamGenerator<T> pg;
 
@@ -44,7 +36,7 @@ public abstract class TransactionExecutor<T extends BenchTransactionType> {
 	protected SutResultSet executeTxn(SutConnection conn, Object[] pars) throws SQLException {
 		SutResultSet result = null;
 		
-		switch (BenchmarkerParameters.CONNECTION_MODE) {
+		switch (VanillaBenchParameters.CONNECTION_MODE) {
 		case JDBC:
 			Connection jdbcConn = conn.toJdbcConnection();
 			jdbcConn.setAutoCommit(false);

--- a/src/main/java/org/vanilladb/bench/server/StartUp.java
+++ b/src/main/java/org/vanilladb/bench/server/StartUp.java
@@ -15,14 +15,14 @@
  *******************************************************************************/
 package org.vanilladb.bench.server;
 
-import org.vanilladb.bench.BenchmarkerParameters;
+import org.vanilladb.bench.VanillaBenchParameters;
 
 public class StartUp {
 
 	public static void main(String[] args) throws Exception {
 		SutStartUp sut = null;
 		
-		switch (BenchmarkerParameters.CONNECTION_MODE) {
+		switch (VanillaBenchParameters.CONNECTION_MODE) {
 		case JDBC:
 			sut = new VanillaDbJdbcStartUp();
 			break;

--- a/src/main/java/org/vanilladb/bench/server/VanillaDbSpStartUp.java
+++ b/src/main/java/org/vanilladb/bench/server/VanillaDbSpStartUp.java
@@ -18,7 +18,7 @@ package org.vanilladb.bench.server;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.vanilladb.bench.BenchmarkerParameters;
+import org.vanilladb.bench.VanillaBenchParameters;
 import org.vanilladb.bench.server.procedure.BasicStoredProcFactory;
 import org.vanilladb.bench.server.procedure.micro.MicrobenchStoredProcFactory;
 import org.vanilladb.bench.server.procedure.tpcc.TpccStoredProcFactory;
@@ -50,7 +50,7 @@ public class VanillaDbSpStartUp implements SutStartUp {
 	
 	private StoredProcedureFactory getStoredProcedureFactory() {
 		StoredProcedureFactory factory = null;
-		switch (BenchmarkerParameters.BENCH_TYPE) {
+		switch (VanillaBenchParameters.BENCH_TYPE) {
 		case MICRO:
 			if (logger.isLoggable(Level.INFO))
 				logger.info("using Micro-benchmark stored procedures");

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpcc/TpccCheckDatabaseProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpcc/TpccCheckDatabaseProc.java
@@ -4,6 +4,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.vanilladb.bench.benchmarks.tpcc.TpccConstants;
+import org.vanilladb.bench.benchmarks.tpcc.TpccParameters;
 import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
 import org.vanilladb.core.query.algebra.Scan;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
@@ -26,7 +27,7 @@ public class TpccCheckDatabaseProc extends StoredProcedure<StoredProcedureParamH
 			abort("item table is not ready");
 		
 		// Checking each warehouse
-		for (int wid = 1; wid <= TpccConstants.NUM_WAREHOUSES; wid++)
+		for (int wid = 1; wid <= TpccParameters.NUM_WAREHOUSES; wid++)
 			if (!checkWarehouse(wid))
 				abort("warehouse " + wid + " is not ready");
 

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpcc/TpccTestbedLoaderProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpcc/TpccTestbedLoaderProc.java
@@ -19,6 +19,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.vanilladb.bench.benchmarks.tpcc.TpccConstants;
+import org.vanilladb.bench.benchmarks.tpcc.TpccParameters;
 import org.vanilladb.bench.benchmarks.tpcc.TpccValueGenerator;
 import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
 import org.vanilladb.bench.util.DoublePlainPrinter;
@@ -52,7 +53,7 @@ public class TpccTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 		generateItems(1, TpccConstants.NUM_ITEMS);
 
 		// Generate warehouse
-		for (int wid = 1; wid <= TpccConstants.NUM_WAREHOUSES; wid++)
+		for (int wid = 1; wid <= TpccParameters.NUM_WAREHOUSES; wid++)
 			generateWarehouseInstance(wid);
 
 		if (logger.isLoggable(Level.INFO))

--- a/src/main/resources/org/vanilladb/bench/vanillabench.properties
+++ b/src/main/resources/org/vanilladb/bench/vanillabench.properties
@@ -19,29 +19,29 @@
 #
 
 # The running time for warming up before benchmarking
-org.vanilladb.bench.BenchmarkerParameters.WARM_UP_INTERVAL=60000
+org.vanilladb.bench.VanillaBenchParameters.WARM_UP_INTERVAL=60000
 # The running time for benchmarking
-org.vanilladb.bench.BenchmarkerParameters.BENCHMARK_INTERVAL=60000
+org.vanilladb.bench.VanillaBenchParameters.BENCHMARK_INTERVAL=60000
 # The number of remote terminal executors for benchmarking
-org.vanilladb.bench.BenchmarkerParameters.NUM_RTES=2
+org.vanilladb.bench.VanillaBenchParameters.NUM_RTES=2
 # The sleeping time (in milliseconds) between transactions for each RTE
 # 0 = no sleeping, 100 is a generally good number for under-loaded workloads
-org.vanilladb.bench.BenchmarkerParameters.RTE_SLEEP_TIME=0
+org.vanilladb.bench.VanillaBenchParameters.RTE_SLEEP_TIME=0
 # The IP of the target database server
-org.vanilladb.bench.BenchmarkerParameters.SERVER_IP=127.0.0.1
+org.vanilladb.bench.VanillaBenchParameters.SERVER_IP=127.0.0.1
 # 1 = JDBC, 2 = Stored Procedures
-org.vanilladb.bench.BenchmarkerParameters.CONNECTION_MODE=2
+org.vanilladb.bench.VanillaBenchParameters.CONNECTION_MODE=2
 # 1 = Micro, 2 = TPC-C, 3 = TPC-E, 4 = YCSB
 # TPC-E dose not work for now
-org.vanilladb.bench.BenchmarkerParameters.BENCH_TYPE=2
+org.vanilladb.bench.VanillaBenchParameters.BENCH_TYPE=2
 # Whether it enables the built-in profiler on the server
-org.vanilladb.bench.BenchmarkerParameters.PROFILING_ON_SERVER=false
+org.vanilladb.bench.VanillaBenchParameters.PROFILING_ON_SERVER=false
 # The path to the generated reports
-org.vanilladb.bench.StatisticMgr.OUTPUT_DIR=
+org.vanilladb.bench.VanillaBenchParameters.REPORT_OUTPUT_DIRECTORY=
 # The granularity for summarizing the performance of benchmarking 
-org.vanilladb.bench.StatisticMgr.GRANULARITY=1000
+org.vanilladb.bench.VanillaBenchParameters.REPORT_TIMELINE_GRANULARITY=1000
 # Whether the RTEs display the results of each transaction
-org.vanilladb.bench.rte.TransactionExecutor.DISPLAY_RESULT=false
+org.vanilladb.bench.VanillaBenchParameters.SHOW_TXN_RESPONSE_ON_CONSOLE=false
 
 
 #

--- a/src/main/resources/org/vanilladb/bench/vanillabench.properties
+++ b/src/main/resources/org/vanilladb/bench/vanillabench.properties
@@ -69,24 +69,24 @@ org.vanilladb.bench.benchmarks.micro.rte.MicrobenchmarkParamGen.HOT_CONFLICT_RAT
 #
 
 # The number of warehouses in the testing data set
-org.vanilladb.bench.benchmarks.tpcc.TpccConstants.NUM_WAREHOUSES=1
+org.vanilladb.bench.benchmarks.tpcc.TpccParameters.NUM_WAREHOUSES=1
 # The total number of frequency
-org.vanilladb.bench.benchmarks.tpcc.TpccConstants.FREQUENCY_TOTAL=100
+org.vanilladb.bench.benchmarks.tpcc.TpccParameters.FREQUENCY_TOTAL=100
 # The frequency of new-order transactions
-org.vanilladb.bench.benchmarks.tpcc.TpccConstants.FREQUENCY_NEW_ORDER=50
+org.vanilladb.bench.benchmarks.tpcc.TpccParameters.FREQUENCY_NEW_ORDER=50
 # The frequency of payment transactions
-org.vanilladb.bench.benchmarks.tpcc.TpccConstants.FREQUENCY_PAYMENT=50
+org.vanilladb.bench.benchmarks.tpcc.TpccParameters.FREQUENCY_PAYMENT=50
 # The frequency of order-status transactions
 # XXX: Not implemented
-org.vanilladb.bench.benchmarks.tpcc.TpccConstants.FREQUENCY_ORDER_STATUS=0
+org.vanilladb.bench.benchmarks.tpcc.TpccParameters.FREQUENCY_ORDER_STATUS=0
 # The frequency of delivery transactions
 # XXX: Not implemented
-org.vanilladb.bench.benchmarks.tpcc.TpccConstants.FREQUENCY_DELIVERY=0
+org.vanilladb.bench.benchmarks.tpcc.TpccParameters.FREQUENCY_DELIVERY=0
 # The frequency of stock-level transactions
 # XXX: Not implemented
-org.vanilladb.bench.benchmarks.tpcc.TpccConstants.FREQUENCY_STOCK_LEVEL=0
+org.vanilladb.bench.benchmarks.tpcc.TpccParameters.FREQUENCY_STOCK_LEVEL=0
 # Whether it enables the thinking and keying time defined in TPC-C specification
-org.vanilladb.bench.benchmarks.tpcc.rte.TpccTxExecutor.ENABLE_THINK_AND_KEYING_TIME=false
+org.vanilladb.bench.benchmarks.tpcc.TpccParameters.ENABLE_THINK_AND_KEYING_TIME=false
 
 
 #


### PR DESCRIPTION
- Rename `BenchmarkerParameters` to `VanillaBenchParameters`
- Move all generate configuration to `VanillaBenchParameters`
- Make RTE's sleep time become a parameter during construction