### PR TITLE
Update SP implementation for VanillaCore 0.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
 		<dependency>
 			<groupId>org.vanilladb</groupId>
 			<artifactId>core</artifactId>
-			<version>0.6.0</version>
+			<version>0.7.0</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/vanilladb/bench/server/param/micro/MicroTxnProcParamHelper.java
+++ b/src/main/java/org/vanilladb/bench/server/param/micro/MicroTxnProcParamHelper.java
@@ -21,9 +21,9 @@ import org.vanilladb.core.sql.Schema;
 import org.vanilladb.core.sql.Type;
 import org.vanilladb.core.sql.VarcharConstant;
 import org.vanilladb.core.sql.storedprocedure.SpResultRecord;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class MicroTxnProcParamHelper extends StoredProcedureParamHelper {
+public class MicroTxnProcParamHelper implements StoredProcedureHelper {
 
 	private int readCount;
 	private int writeCount;
@@ -84,9 +84,11 @@ public class MicroTxnProcParamHelper extends StoredProcedureParamHelper {
 		newItemPrice = new double[writeCount];
 		for (int i = 0; i < writeCount; i++)
 			newItemPrice[i] = (Double) pars[indexCnt++];
-
-		if (writeCount == 0)
-			setReadOnly(true);
+	}
+	
+	@Override
+	public boolean isReadOnly() {
+		return writeCount == 0;
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/server/param/micro/TestbedLoaderParamHelper.java
+++ b/src/main/java/org/vanilladb/bench/server/param/micro/TestbedLoaderParamHelper.java
@@ -17,9 +17,9 @@ package org.vanilladb.bench.server.param.micro;
 
 import org.vanilladb.core.sql.Schema;
 import org.vanilladb.core.sql.storedprocedure.SpResultRecord;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class TestbedLoaderParamHelper extends StoredProcedureParamHelper {
+public class TestbedLoaderParamHelper implements StoredProcedureHelper {
 
 	private static final String TABLES_DDL[] = {
 			"CREATE TABLE item ( i_id INT, i_im_id INT, i_name VARCHAR(24), "
@@ -44,6 +44,11 @@ public class TestbedLoaderParamHelper extends StoredProcedureParamHelper {
 	@Override
 	public void prepareParameters(Object... pars) {
 		numOfItems = (Integer) pars[0];
+	}
+	
+	@Override
+	public boolean isReadOnly() {
+		return false;
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/server/param/tpcc/NewOrderProcParamHelper.java
+++ b/src/main/java/org/vanilladb/bench/server/param/tpcc/NewOrderProcParamHelper.java
@@ -22,9 +22,9 @@ import org.vanilladb.core.sql.Schema;
 import org.vanilladb.core.sql.Type;
 import org.vanilladb.core.sql.VarcharConstant;
 import org.vanilladb.core.sql.storedprocedure.SpResultRecord;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class NewOrderProcParamHelper extends StoredProcedureParamHelper {
+public class NewOrderProcParamHelper implements StoredProcedureHelper {
 	
 	// input parameters
 	protected int wid, did, cid, olCount;
@@ -52,6 +52,11 @@ public class NewOrderProcParamHelper extends StoredProcedureParamHelper {
 			items[i][2] = (Integer) pars[++j];
 		}
 		allLocal = (Boolean) pars[49];
+	}
+	
+	@Override
+	public boolean isReadOnly() {
+		return false;
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/server/param/tpcc/OrderStatusProcParamHelper.java
+++ b/src/main/java/org/vanilladb/bench/server/param/tpcc/OrderStatusProcParamHelper.java
@@ -22,9 +22,9 @@ import org.vanilladb.core.sql.Schema;
 import org.vanilladb.core.sql.Type;
 import org.vanilladb.core.sql.VarcharConstant;
 import org.vanilladb.core.sql.storedprocedure.SpResultRecord;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class OrderStatusProcParamHelper extends StoredProcedureParamHelper {
+public class OrderStatusProcParamHelper implements StoredProcedureHelper {
 	protected boolean selectByCLast;
 	protected int cwid, cdid, cid, oid, carrierId;
 	protected String cLast, cMiddle, cFirst;
@@ -42,6 +42,12 @@ public class OrderStatusProcParamHelper extends StoredProcedureParamHelper {
 			cLast = (String) pars[2];
 		} else
 			cid = (Integer) pars[2];
+	}
+	
+	@Override
+	public boolean isReadOnly() {
+		// TODO: Check if this is correct
+		return true;
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/server/param/tpcc/PaymentProcParamHelper.java
+++ b/src/main/java/org/vanilladb/bench/server/param/tpcc/PaymentProcParamHelper.java
@@ -22,9 +22,9 @@ import org.vanilladb.core.sql.Schema;
 import org.vanilladb.core.sql.Type;
 import org.vanilladb.core.sql.VarcharConstant;
 import org.vanilladb.core.sql.storedprocedure.SpResultRecord;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class PaymentProcParamHelper extends StoredProcedureParamHelper {
+public class PaymentProcParamHelper implements StoredProcedureHelper {
 
 	protected int wid, did, cwid, cdid, cid;
 	protected String cDataStr, cLast, cMiddle, cFirst, cStreet1, cStreet2, cCity, cState, cZip, cPhone, cCredit;
@@ -46,6 +46,11 @@ public class PaymentProcParamHelper extends StoredProcedureParamHelper {
 		cdid = (Integer) pars[3];
 		cid = (Integer) pars[4];
 		hAmount = (Double) pars[5];
+	}
+	
+	@Override
+	public boolean isReadOnly() {
+		return false;
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/server/param/tpcc/TpccSchemaBuilderProcParamHelper.java
+++ b/src/main/java/org/vanilladb/bench/server/param/tpcc/TpccSchemaBuilderProcParamHelper.java
@@ -17,9 +17,9 @@ package org.vanilladb.bench.server.param.tpcc;
 
 import org.vanilladb.core.sql.Schema;
 import org.vanilladb.core.sql.storedprocedure.SpResultRecord;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class TpccSchemaBuilderProcParamHelper extends StoredProcedureParamHelper {
+public class TpccSchemaBuilderProcParamHelper implements StoredProcedureHelper {
 
 	private final String TABLES_DDL[] = {
 			"CREATE TABLE warehouse ( w_id INT, w_name VARCHAR(10), "
@@ -76,6 +76,11 @@ public class TpccSchemaBuilderProcParamHelper extends StoredProcedureParamHelper
 	@Override
 	public void prepareParameters(Object... pars) {
 		// nothing to do
+	}
+	
+	@Override
+	public boolean isReadOnly() {
+		return false;
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/server/param/tpce/TpceSchemaBuilderParamHelper.java
+++ b/src/main/java/org/vanilladb/bench/server/param/tpce/TpceSchemaBuilderParamHelper.java
@@ -17,9 +17,9 @@ package org.vanilladb.bench.server.param.tpce;
 
 import org.vanilladb.core.sql.Schema;
 import org.vanilladb.core.sql.storedprocedure.SpResultRecord;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class TpceSchemaBuilderParamHelper extends StoredProcedureParamHelper {
+public class TpceSchemaBuilderParamHelper implements StoredProcedureHelper {
 
 	private static final String TABLES_DDL[] = {
 			// Customer Category
@@ -98,6 +98,11 @@ public class TpceSchemaBuilderParamHelper extends StoredProcedureParamHelper {
 	@Override
 	public void prepareParameters(Object... pars) {
 		// nothing to do
+	}
+	
+	@Override
+	public boolean isReadOnly() {
+		return false;
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/server/param/tpce/TradeOrderParamHelper.java
+++ b/src/main/java/org/vanilladb/bench/server/param/tpce/TradeOrderParamHelper.java
@@ -20,9 +20,9 @@ import org.vanilladb.core.sql.DoubleConstant;
 import org.vanilladb.core.sql.Schema;
 import org.vanilladb.core.sql.Type;
 import org.vanilladb.core.sql.storedprocedure.SpResultRecord;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class TradeOrderParamHelper extends StoredProcedureParamHelper {
+public class TradeOrderParamHelper implements StoredProcedureHelper {
 	
 	// Inputs
 	private long acctId;
@@ -58,6 +58,11 @@ public class TradeOrderParamHelper extends StoredProcedureParamHelper {
 		tradeQty = (Integer) pars[7];
 		tradeTypeId = (String) pars[8];
 		tradeId = (Long) pars[9];
+	}
+	
+	@Override
+	public boolean isReadOnly() {
+		return false;
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/server/param/tpce/TradeResultParamHelper.java
+++ b/src/main/java/org/vanilladb/bench/server/param/tpce/TradeResultParamHelper.java
@@ -21,9 +21,9 @@ import org.vanilladb.core.sql.IntegerConstant;
 import org.vanilladb.core.sql.Schema;
 import org.vanilladb.core.sql.Type;
 import org.vanilladb.core.sql.storedprocedure.SpResultRecord;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class TradeResultParamHelper extends StoredProcedureParamHelper {
+public class TradeResultParamHelper implements StoredProcedureHelper {
 	
 	// Inputs
 	private long tradeId;
@@ -47,6 +47,11 @@ public class TradeResultParamHelper extends StoredProcedureParamHelper {
 		customerId = (Long) pars[idxCntr++];
 		acctId = (Long) pars[idxCntr++];
 		brokerId = (Long) pars[idxCntr++];
+	}
+	
+	@Override
+	public boolean isReadOnly() {
+		return false;
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/server/param/ycsb/YcsbBenchmarkProcParamHelper.java
+++ b/src/main/java/org/vanilladb/bench/server/param/ycsb/YcsbBenchmarkProcParamHelper.java
@@ -8,9 +8,9 @@ import org.vanilladb.core.sql.Schema;
 import org.vanilladb.core.sql.Type;
 import org.vanilladb.core.sql.VarcharConstant;
 import org.vanilladb.core.sql.storedprocedure.SpResultRecord;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class YcsbBenchmarkProcParamHelper extends StoredProcedureParamHelper {
+public class YcsbBenchmarkProcParamHelper implements StoredProcedureHelper {
 	
 	private int readCount;
 	private int writeCount;
@@ -110,9 +110,11 @@ public class YcsbBenchmarkProcParamHelper extends StoredProcedureParamHelper {
 		insertVals = new String[insertCount];
 		for (int i = 0; i < insertCount; i++)
 			insertVals[i] = (String) pars[indexCnt++];
-
-		if (writeCount == 0 && insertCount == 0)
-			setReadOnly(true);
+	}
+	
+	@Override
+	public boolean isReadOnly() {
+		return writeCount == 0;
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/server/param/ycsb/YcsbSchemaBuilderProcParamHelper.java
+++ b/src/main/java/org/vanilladb/bench/server/param/ycsb/YcsbSchemaBuilderProcParamHelper.java
@@ -3,9 +3,9 @@ package org.vanilladb.bench.server.param.ycsb;
 import org.vanilladb.bench.benchmarks.ycsb.YcsbConstants;
 import org.vanilladb.core.sql.Schema;
 import org.vanilladb.core.sql.storedprocedure.SpResultRecord;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class YcsbSchemaBuilderProcParamHelper extends StoredProcedureParamHelper {
+public class YcsbSchemaBuilderProcParamHelper implements StoredProcedureHelper {
 	private static final String YCSB_DDL;
 	
 	static {
@@ -43,6 +43,11 @@ public class YcsbSchemaBuilderProcParamHelper extends StoredProcedureParamHelper
 	@Override
 	public void prepareParameters(Object... pars) {
 		// nothing to do
+	}
+	
+	@Override
+	public boolean isReadOnly() {
+		return false;
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/server/procedure/BasicStoredProcFactory.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/BasicStoredProcFactory.java
@@ -13,7 +13,7 @@ public class BasicStoredProcFactory implements StoredProcedureFactory {
 	}
 
 	@Override
-	public StoredProcedure<?> getStroredProcedure(int pid) {
+	public StoredProcedure<?> getStoredProcedure(int pid) {
 		ControlTransactionType txnType = ControlTransactionType.fromProcedureId(pid);
 		if (txnType != null) {
 			switch (txnType) {
@@ -24,6 +24,6 @@ public class BasicStoredProcFactory implements StoredProcedureFactory {
 			}
 		}
 		
-		return underlayerFactory.getStroredProcedure(pid);
+		return underlayerFactory.getStoredProcedure(pid);
 	}
 }

--- a/src/main/java/org/vanilladb/bench/server/procedure/StartProfilingProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/StartProfilingProc.java
@@ -17,12 +17,12 @@ package org.vanilladb.bench.server.procedure;
 
 import org.vanilladb.core.server.VanillaDb;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class StartProfilingProc extends StoredProcedure<StoredProcedureParamHelper> {
+public class StartProfilingProc extends StoredProcedure<StoredProcedureHelper> {
 
 	public StartProfilingProc() {
-		super(StoredProcedureParamHelper.newDefaultParamHelper());
+		super(StoredProcedureHelper.DEFAULT_HELPER);
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/server/procedure/StopProfilingProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/StopProfilingProc.java
@@ -17,12 +17,12 @@ package org.vanilladb.bench.server.procedure;
 
 import org.vanilladb.core.server.VanillaDb;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class StopProfilingProc extends StoredProcedure<StoredProcedureParamHelper> {
+public class StopProfilingProc extends StoredProcedure<StoredProcedureHelper> {
 
 	public StopProfilingProc() {
-		super(StoredProcedureParamHelper.newDefaultParamHelper());
+		super(StoredProcedureHelper.DEFAULT_HELPER);
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/server/procedure/StoredProcedureUtils.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/StoredProcedureUtils.java
@@ -20,7 +20,7 @@ import org.vanilladb.core.query.algebra.Scan;
 import org.vanilladb.core.server.VanillaDb;
 import org.vanilladb.core.storage.tx.Transaction;
 
-public class StoredProcedureHelper {
+public class StoredProcedureUtils {
 	
 	public static Scan executeQuery(String sql, Transaction tx) {
 		Plan p = VanillaDb.newPlanner().createQueryPlan(sql, tx);

--- a/src/main/java/org/vanilladb/bench/server/procedure/micro/MicroCheckDatabaseProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/micro/MicroCheckDatabaseProc.java
@@ -4,7 +4,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.vanilladb.bench.server.param.micro.TestbedLoaderParamHelper;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.core.query.algebra.Scan;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
 
@@ -21,7 +21,7 @@ public class MicroCheckDatabaseProc extends StoredProcedure<TestbedLoaderParamHe
 			logger.info("Checking database for the micro benchmarks...");
 
 		// Checking item records
-		if (!checkItemTable(1, getParamHelper().getNumberOfItems()))
+		if (!checkItemTable(1, getHelper().getNumberOfItems()))
 			abort("checking database fails");
 
 		if (logger.isLoggable(Level.INFO))
@@ -40,7 +40,7 @@ public class MicroCheckDatabaseProc extends StoredProcedure<TestbedLoaderParamHe
 		
 		// Scan the table
 		String sql = "SELECT i_id FROM item";
-		Scan scan = StoredProcedureHelper.executeQuery(sql, getTransaction());
+		Scan scan = StoredProcedureUtils.executeQuery(sql, getTransaction());
 		scan.beforeFirst();
 		for (int i = startIId, count = 0; i <= endIId; i++) {
 			if (!scan.next()) {

--- a/src/main/java/org/vanilladb/bench/server/procedure/micro/MicroTestbedLoaderProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/micro/MicroTestbedLoaderProc.java
@@ -20,7 +20,7 @@ import java.util.logging.Logger;
 
 import org.vanilladb.bench.benchmarks.tpcc.TpccConstants;
 import org.vanilladb.bench.server.param.micro.TestbedLoaderParamHelper;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.core.server.VanillaDb;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
 import org.vanilladb.core.storage.tx.Transaction;
@@ -47,7 +47,7 @@ public class MicroTestbedLoaderProc extends StoredProcedure<TestbedLoaderParamHe
 		createSchemas();
 
 		// Generate item records
-		generateItems(1, getParamHelper().getNumberOfItems());
+		generateItems(1, getHelper().getNumberOfItems());
 
 		if (logger.isLoggable(Level.INFO))
 			logger.info("Loading completed. Flush all loading data to disks...");
@@ -74,20 +74,20 @@ public class MicroTestbedLoaderProc extends StoredProcedure<TestbedLoaderParamHe
 	}
 	
 	private void createSchemas() {
-		TestbedLoaderParamHelper paramHelper = getParamHelper();
+		TestbedLoaderParamHelper paramHelper = getHelper();
 		Transaction tx = getTransaction();
 		
 		if (logger.isLoggable(Level.FINE))
 			logger.info("Create tables...");
 		
 		for (String sql : paramHelper.getTableSchemas())
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		
 		if (logger.isLoggable(Level.FINE))
 			logger.info("Create indexes...");
 
 		for (String sql : paramHelper.getIndexSchemas())
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		
 		if (logger.isLoggable(Level.FINE))
 			logger.info("Finish creating schemas.");
@@ -113,7 +113,7 @@ public class MicroTestbedLoaderProc extends StoredProcedure<TestbedLoaderParamHe
 
 			sql = "INSERT INTO item(i_id, i_im_id, i_name, i_price, i_data) VALUES (" + iid + ", " + iimid + ", '"
 					+ iname + "', " + iprice + ", '" + idata + "' )";
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		}
 
 		if (logger.isLoggable(Level.FINE))

--- a/src/main/java/org/vanilladb/bench/server/procedure/micro/MicroTxnProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/micro/MicroTxnProc.java
@@ -16,7 +16,7 @@
 package org.vanilladb.bench.server.procedure.micro;
 
 import org.vanilladb.bench.server.param.micro.MicroTxnProcParamHelper;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.core.query.algebra.Scan;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
 import org.vanilladb.core.storage.tx.Transaction;
@@ -29,13 +29,13 @@ public class MicroTxnProc extends StoredProcedure<MicroTxnProcParamHelper> {
 
 	@Override
 	protected void executeSql() {
-		MicroTxnProcParamHelper paramHelper = getParamHelper();
+		MicroTxnProcParamHelper paramHelper = getHelper();
 		Transaction tx = getTransaction();
 		
 		// SELECT
 		for (int idx = 0; idx < paramHelper.getReadCount(); idx++) {
 			int iid = paramHelper.getReadItemId(idx);
-			Scan s = StoredProcedureHelper.executeQuery(
+			Scan s = StoredProcedureUtils.executeQuery(
 				"SELECT i_name, i_price FROM item WHERE i_id = " + iid,
 				tx
 			);
@@ -56,7 +56,7 @@ public class MicroTxnProc extends StoredProcedure<MicroTxnProcParamHelper> {
 		for (int idx = 0; idx < paramHelper.getWriteCount(); idx++) {
 			int iid = paramHelper.getWriteItemId(idx);
 			double newPrice = paramHelper.getNewItemPrice(idx);
-			StoredProcedureHelper.executeUpdate(
+			StoredProcedureUtils.executeUpdate(
 				"UPDATE item SET i_price = " + newPrice + " WHERE i_id =" + iid,
 				tx
 			);

--- a/src/main/java/org/vanilladb/bench/server/procedure/micro/MicrobenchStoredProcFactory.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/micro/MicrobenchStoredProcFactory.java
@@ -22,7 +22,7 @@ import org.vanilladb.core.sql.storedprocedure.StoredProcedureFactory;
 public class MicrobenchStoredProcFactory implements StoredProcedureFactory {
 
 	@Override
-	public StoredProcedure<?> getStroredProcedure(int pid) {
+	public StoredProcedure<?> getStoredProcedure(int pid) {
 		StoredProcedure<?> sp;
 		switch (MicrobenchTransactionType.fromProcedureId(pid)) {
 		case TESTBED_LOADER:

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpcc/PaymentProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpcc/PaymentProc.java
@@ -16,7 +16,7 @@
 package org.vanilladb.bench.server.procedure.tpcc;
 
 import org.vanilladb.bench.server.param.tpcc.PaymentProcParamHelper;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.core.query.algebra.Scan;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
 import org.vanilladb.core.storage.tx.Transaction;
@@ -29,7 +29,7 @@ public class PaymentProc extends StoredProcedure<PaymentProcParamHelper> {
 
 	@Override
 	protected void executeSql() {
-		PaymentProcParamHelper paramHelper = getParamHelper();
+		PaymentProcParamHelper paramHelper = getHelper();
 		Transaction tx = getTransaction();
 		int wid = paramHelper.getWid();
 		int did = paramHelper.getDid();
@@ -42,7 +42,7 @@ public class PaymentProc extends StoredProcedure<PaymentProcParamHelper> {
 		// FROM warehouse WHERE w_id = wid;
 		String sql = "SELECT w_name, w_street_1, w_street_2, w_city,w_state, w_zip, w_ytd "
 				+ "FROM warehouse WHERE w_id = " + wid;
-		Scan s = StoredProcedureHelper.executeQuery(sql, tx);
+		Scan s = StoredProcedureUtils.executeQuery(sql, tx);
 		s.beforeFirst();
 		if (!s.next())
 			throw new RuntimeException("Executing '" + sql + "' fails");
@@ -59,13 +59,13 @@ public class PaymentProc extends StoredProcedure<PaymentProcParamHelper> {
 		sql = "UPDATE warehouse SET w_ytd = " + 
 				String.format("%f", wYtd + hAmount) +
 				" WHERE w_id = " + wid;
-		StoredProcedureHelper.executeUpdate(sql, tx);
+		StoredProcedureUtils.executeUpdate(sql, tx);
 		
 		// SELECT d_name, d_street_1, d_street_2, d_city, d_state, d_zip, d_ytd
 		// FROM district WHERE d_w_id = wid AND d_id = did;
 		sql = "SELECT d_name, d_street_1, d_street_2, d_city, d_state, d_zip, d_ytd "
 				+ "FROM district WHERE d_w_id = " + wid + " AND d_id = " + did;
-		s = StoredProcedureHelper.executeQuery(sql, tx);
+		s = StoredProcedureUtils.executeQuery(sql, tx);
 		s.beforeFirst();
 		if (!s.next())
 			throw new RuntimeException("Executing '" + sql + "' fails");
@@ -83,7 +83,7 @@ public class PaymentProc extends StoredProcedure<PaymentProcParamHelper> {
 		sql = "UPDATE district SET d_ytd = " + 
 				String.format("%f", dYtd + hAmount) +
 				" WHERE d_w_id = " + wid + " AND d_id = " + did;
-		StoredProcedureHelper.executeUpdate(sql, tx);
+		StoredProcedureUtils.executeUpdate(sql, tx);
 		
 		// TODO: Add select by name
 		
@@ -97,7 +97,7 @@ public class PaymentProc extends StoredProcedure<PaymentProcParamHelper> {
 				"c_state, c_zip, c_phone, c_credit, c_credit_lim, " +
 				"c_discount, c_balance, c_since FROM customer " +
 				"WHERE c_w_id = " + cwid + " AND c_d_id = " + cdid + " AND c_id = " + cid;
-		s = StoredProcedureHelper.executeQuery(sql, tx);
+		s = StoredProcedureUtils.executeQuery(sql, tx);
 		s.beforeFirst();
 		if (!s.next())
 			throw new RuntimeException("Executing '" + sql + "' fails");
@@ -128,7 +128,7 @@ public class PaymentProc extends StoredProcedure<PaymentProcParamHelper> {
 			// c_d_id = cdid AND c_id = cid;
 			sql = "SELECT c_data FROM customer WHERE c_w_id = " + cwid +
 					" AND c_d_id = " + cdid + " AND c_id = " + cid;
-			s = StoredProcedureHelper.executeQuery(sql, tx);
+			s = StoredProcedureUtils.executeQuery(sql, tx);
 			s.beforeFirst();
 			if (!s.next())
 				throw new RuntimeException("Executing '" + sql + "' fails");
@@ -148,7 +148,7 @@ public class PaymentProc extends StoredProcedure<PaymentProcParamHelper> {
 					String.format("%f", cBalance) +
 					", c_data = '" + cNewData + "' WHERE c_w_id = " + cwid +
 					" AND c_d_id = " + cdid + " AND c_id = " + cid;
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		} else {
 			// UPDATE customer SET c_balance = cBalance
 			// WHERE c_w_id = cwid AND c_d_id = cdid AND c_id = cid
@@ -156,7 +156,7 @@ public class PaymentProc extends StoredProcedure<PaymentProcParamHelper> {
 					String.format("%f", cBalance) +
 					" WHERE c_w_id = " + cwid +
 					" AND c_d_id = " + cdid + " AND c_id = " + cid;
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		}
 		
 		String hData = wName + "    " + dName;
@@ -170,6 +170,6 @@ public class PaymentProc extends StoredProcedure<PaymentProcParamHelper> {
 				+ "h_w_id, h_date, h_amount, h_data) VALUES ( %d, %d, %d, %d, "
 				+ "%d, %d, %f, '%s')",
 				cid, cdid, cwid, did, wid, hDate, hAmount, hData);
-		StoredProcedureHelper.executeUpdate(sql, tx);
+		StoredProcedureUtils.executeUpdate(sql, tx);
 	}
 }

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpcc/TpccCheckDatabaseProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpcc/TpccCheckDatabaseProc.java
@@ -5,16 +5,16 @@ import java.util.logging.Logger;
 
 import org.vanilladb.bench.benchmarks.tpcc.TpccConstants;
 import org.vanilladb.bench.benchmarks.tpcc.TpccParameters;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.core.query.algebra.Scan;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class TpccCheckDatabaseProc extends StoredProcedure<StoredProcedureParamHelper> {
+public class TpccCheckDatabaseProc extends StoredProcedure<StoredProcedureHelper> {
 	private static Logger logger = Logger.getLogger(TpccCheckDatabaseProc.class.getName());
 	
 	public TpccCheckDatabaseProc() {
-		super(StoredProcedureParamHelper.newDefaultParamHelper());
+		super(StoredProcedureHelper.DEFAULT_HELPER);
 	}
 
 	@Override
@@ -55,7 +55,7 @@ public class TpccCheckDatabaseProc extends StoredProcedure<StoredProcedureParamH
 		
 		// Check warehouse records
 		String sql = "SELECT w_id FROM warehouse WHERE w_id = " + wid;
-		Scan s = StoredProcedureHelper.executeQuery(sql, getTransaction());
+		Scan s = StoredProcedureUtils.executeQuery(sql, getTransaction());
 		s.beforeFirst();
 		if (!s.next())
 			return false;
@@ -152,7 +152,7 @@ public class TpccCheckDatabaseProc extends StoredProcedure<StoredProcedureParamH
 			checked[i] = false;
 		
 		// Check records
-		Scan scan = StoredProcedureHelper.executeQuery(sql, getTransaction());
+		Scan scan = StoredProcedureUtils.executeQuery(sql, getTransaction());
 		scan.beforeFirst();
 		for (int count = 0; count < total; count++) {
 			if (!scan.next()) {
@@ -183,7 +183,7 @@ public class TpccCheckDatabaseProc extends StoredProcedure<StoredProcedureParamH
 			checked[i] = false;
 		
 		// Check records
-		Scan scan = StoredProcedureHelper.executeQuery(sql, getTransaction());
+		Scan scan = StoredProcedureUtils.executeQuery(sql, getTransaction());
 		scan.beforeFirst();
 		while (scan.next()) {
 			int id = (Integer) scan.getVal(checkField).asJavaVal();

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpcc/TpccSchemaBuilderProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpcc/TpccSchemaBuilderProc.java
@@ -16,7 +16,7 @@
 package org.vanilladb.bench.server.procedure.tpcc;
 
 import org.vanilladb.bench.server.param.tpcc.TpccSchemaBuilderProcParamHelper;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
 import org.vanilladb.core.storage.tx.Transaction;
 
@@ -28,11 +28,11 @@ public class TpccSchemaBuilderProc extends StoredProcedure<TpccSchemaBuilderProc
 
 	@Override
 	protected void executeSql() {
-		TpccSchemaBuilderProcParamHelper paramHelper = getParamHelper();
+		TpccSchemaBuilderProcParamHelper paramHelper = getHelper();
 		Transaction tx = getTransaction();
 		for (String sql : paramHelper.getTableSchemas())
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		for (String sql : paramHelper.getIndexSchemas())
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 	}
 }

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpcc/TpccStoredProcFactory.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpcc/TpccStoredProcFactory.java
@@ -22,7 +22,7 @@ import org.vanilladb.core.sql.storedprocedure.StoredProcedureFactory;
 public class TpccStoredProcFactory implements StoredProcedureFactory {
 
 	@Override
-	public StoredProcedure<?> getStroredProcedure(int pid) {
+	public StoredProcedure<?> getStoredProcedure(int pid) {
 		StoredProcedure<?> sp;
 		switch (TpccTransactionType.fromProcedureId(pid)) {
 		case SCHEMA_BUILDER:

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpcc/TpccTestbedLoaderProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpcc/TpccTestbedLoaderProc.java
@@ -21,23 +21,23 @@ import java.util.logging.Logger;
 import org.vanilladb.bench.benchmarks.tpcc.TpccConstants;
 import org.vanilladb.bench.benchmarks.tpcc.TpccParameters;
 import org.vanilladb.bench.benchmarks.tpcc.TpccValueGenerator;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.bench.util.DoublePlainPrinter;
 import org.vanilladb.bench.util.RandomPermutationGenerator;
 import org.vanilladb.core.server.VanillaDb;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 import org.vanilladb.core.storage.tx.Transaction;
 import org.vanilladb.core.storage.tx.recovery.CheckpointTask;
 import org.vanilladb.core.storage.tx.recovery.RecoveryMgr;
 
-public class TpccTestbedLoaderProc extends StoredProcedure<StoredProcedureParamHelper> {
+public class TpccTestbedLoaderProc extends StoredProcedure<StoredProcedureHelper> {
 	private static Logger logger = Logger.getLogger(TpccTestbedLoaderProc.class.getName());
 
 	private TpccValueGenerator rg = new TpccValueGenerator();
 
 	public TpccTestbedLoaderProc() {
-		super(StoredProcedureParamHelper.newDefaultParamHelper());
+		super(StoredProcedureHelper.DEFAULT_HELPER);
 	}
 	
 	@Override
@@ -106,7 +106,7 @@ public class TpccTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 
 			sql = "INSERT INTO item(i_id, i_im_id, i_name, i_price, i_data) VALUES (" + iid + ", " + iimid + ", '"
 					+ iname + "', " + DoublePlainPrinter.toPlainString(iprice) + ", '" + idata + "' )";
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		}
 
 		if (logger.isLoggable(Level.FINE))
@@ -160,7 +160,7 @@ public class TpccTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 		sb.append("', '").append(wcity).append("', '").append(wstate);
 		sb.append("', '").append(wzip).append("', ").append(DoublePlainPrinter.toPlainString(wtax));
 		sb.append(", ").append(DoublePlainPrinter.toPlainString(wytd)).append(" )");
-		StoredProcedureHelper.executeUpdate(sb.toString(), tx);
+		StoredProcedureUtils.executeUpdate(sb.toString(), tx);
 	}
 
 	private void generateStocks(int wid) {
@@ -193,7 +193,7 @@ public class TpccTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 					+ "s_ytd, s_order_cnt, s_remote_cnt, s_data) VALUES (" + siid + ", " + swid + ", " + squantity
 					+ ", '" + sd1 + "', '" + sd2 + "', '" + sd3 + "', '" + sd4 + "', '" + sd5 + "', '" + sd6 + "', '"
 					+ sd7 + "', '" + sd8 + "', '" + sd9 + "', '" + sd10 + "', 0, 0, 0, '" + sdata + "')";
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		}
 	}
 
@@ -220,7 +220,7 @@ public class TpccTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 					+ "', '" + dst2 + "', '" + dcity + "', '" + dstate + "', '" + dzip + "', "
 					+ DoublePlainPrinter.toPlainString(dtax) + ", " + DoublePlainPrinter.toPlainString(dytd) + ", "
 					+ (TpccConstants.CUSTOMERS_PER_DISTRICT + 1) + ")";
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		}
 	}
 
@@ -268,7 +268,7 @@ public class TpccTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 					+ DoublePlainPrinter.toPlainString(ccl) + ", " + DoublePlainPrinter.toPlainString(cdiscount) + ", "
 					+ DoublePlainPrinter.toPlainString(cbal) + ", " + DoublePlainPrinter.toPlainString(cytdpay)
 					+ ", 1, 0, '" + cdata + "')";
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		}
 		if (logger.isLoggable(Level.FINE))
 			logger.info("Finish populating customers for district " + did);
@@ -289,7 +289,7 @@ public class TpccTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 					+ "h_d_id,h_w_id, h_date, h_amount, h_data ) VALUES (" + hcid + ", " + did + "," + wid + ","
 					+ did + "," + wid + "," + hdate + "," + DoublePlainPrinter.toPlainString(hamount) + ", '" + hdata
 					+ "')";
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		}
 	}
 
@@ -312,7 +312,7 @@ public class TpccTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 			String sql = "INSERT INTO ORDERS(o_id, o_c_id, o_d_id, "
 					+ "o_w_id, o_entry_d, o_carrier_id, o_ol_cnt, o_all_local) VALUES (" + oid + ", " + ocid + ", "
 					+ did + "," + wid + "," + oenrtyd + "," + ocarid + ", " + ol_cnt + ",1)";
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 
 			generateOrderLine(wid, did, i, ol_cnt, oenrtyd);
 		}
@@ -342,7 +342,7 @@ public class TpccTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 					+ "ol_delivery_d, ol_quantity, ol_amount, ol_dist_info)" + " VALUES (" + orderId + "," + districtId
 					+ "," + warehouseId + "," + olnum + "," + oliid + ", " + warehouseId + ", " + oldeld + ", 5, "
 					+ DoublePlainPrinter.toPlainString(olamount) + ", '" + oldistinfo + "')";
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		}
 	}
 
@@ -353,7 +353,7 @@ public class TpccTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 			nooid = i;
 			String sql = "INSERT INTO new_order(no_o_id, no_d_id, no_w_id) VALUES (" + nooid + "," + did + "," + wid
 					+ ")";
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		}
 	}
 

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpce/TpceCheckDatabaseProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpce/TpceCheckDatabaseProc.java
@@ -4,13 +4,13 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class TpceCheckDatabaseProc extends StoredProcedure<StoredProcedureParamHelper> {
+public class TpceCheckDatabaseProc extends StoredProcedure<StoredProcedureHelper> {
 	private static Logger logger = Logger.getLogger(TpceCheckDatabaseProc.class.getName());
 	
 	public TpceCheckDatabaseProc() {
-		super(StoredProcedureParamHelper.newDefaultParamHelper());
+		super(StoredProcedureHelper.DEFAULT_HELPER);
 	}
 
 	@Override

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpce/TpceSchemaBuilderProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpce/TpceSchemaBuilderProc.java
@@ -19,7 +19,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.vanilladb.bench.server.param.tpce.TpceSchemaBuilderParamHelper;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
 import org.vanilladb.core.storage.tx.Transaction;
 
@@ -35,11 +35,11 @@ public class TpceSchemaBuilderProc extends StoredProcedure<TpceSchemaBuilderPara
 		if (logger.isLoggable(Level.FINE))
 			logger.info("Create schema for tpce testbed...");
 
-		TpceSchemaBuilderParamHelper paramHelper = getParamHelper();
+		TpceSchemaBuilderParamHelper paramHelper = getHelper();
 		Transaction tx = getTransaction();
 		for (String sql : paramHelper.getTableSchemas())
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		for (String sql : paramHelper.getIndexSchemas())
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 	}
 }

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpce/TpceStoredProcFactory.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpce/TpceStoredProcFactory.java
@@ -22,7 +22,7 @@ import org.vanilladb.core.sql.storedprocedure.StoredProcedureFactory;
 public class TpceStoredProcFactory implements StoredProcedureFactory {
 
 	@Override
-	public StoredProcedure<?> getStroredProcedure(int pid) {
+	public StoredProcedure<?> getStoredProcedure(int pid) {
 		StoredProcedure<?> sp;
 		switch (TpceTransactionType.fromProcedureId(pid)) {
 		case SCHEMA_BUILDER:

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpce/TpceTestbedLoaderProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpce/TpceTestbedLoaderProc.java
@@ -26,15 +26,15 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.vanilladb.bench.benchmarks.tpce.data.TpceDataManager;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.core.server.VanillaDb;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 import org.vanilladb.core.storage.tx.Transaction;
 import org.vanilladb.core.storage.tx.recovery.CheckpointTask;
 import org.vanilladb.core.storage.tx.recovery.RecoveryMgr;
 
-public class TpceTestbedLoaderProc extends StoredProcedure<StoredProcedureParamHelper> {
+public class TpceTestbedLoaderProc extends StoredProcedure<StoredProcedureHelper> {
 	private static Logger logger = Logger.getLogger(TpceTestbedLoaderProc.class.getName());
 	
 	private static interface RowProcessor {
@@ -42,7 +42,7 @@ public class TpceTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 	}
 
 	public TpceTestbedLoaderProc() {
-		super(StoredProcedureParamHelper.newDefaultParamHelper());
+		super(StoredProcedureHelper.DEFAULT_HELPER);
 	}
 
 	@Override
@@ -127,7 +127,7 @@ public class TpceTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 						columns[12], columns[13], columns[14], columns[15], columns[16],
 						columns[17], columns[18], columns[19], columns[20], columns[21],
 						columns[22], columns[23]);
-				StoredProcedureHelper.executeUpdate(sql, tx);
+				StoredProcedureUtils.executeUpdate(sql, tx);
 			}
 			
 		});
@@ -143,7 +143,7 @@ public class TpceTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 						+ "ca_c_id, ca_name, ca_tax_st, ca_bal) VALUES (%s, %s, %s, '%s', "
 						+ "%s, %s)", columns[0], columns[1], columns[2], columns[3], 
 						columns[4], columns[5]);
-				StoredProcedureHelper.executeUpdate(sql, tx);
+				StoredProcedureUtils.executeUpdate(sql, tx);
 			}
 			
 		});
@@ -158,7 +158,7 @@ public class TpceTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 				String sql = String.format("INSERT INTO broker (b_id, b_st_id, b_name, "
 						+ "b_num_trades, b_comm_total) VALUES (%s, '%s', '%s', %s, %s)", 
 						columns[0], columns[1], columns[2], columns[3], columns[4]);
-				StoredProcedureHelper.executeUpdate(sql, tx);
+				StoredProcedureUtils.executeUpdate(sql, tx);
 			}
 			
 		});
@@ -173,7 +173,7 @@ public class TpceTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 				String sql = String.format("INSERT INTO trade_type (tt_id, tt_name, "
 						+ "tt_is_sell, tt_is_mrkt) VALUES ('%s', '%s', %s, %s)", 
 						columns[0], columns[1], columns[2], columns[3]);
-				StoredProcedureHelper.executeUpdate(sql, tx);
+				StoredProcedureUtils.executeUpdate(sql, tx);
 			}
 			
 		});
@@ -192,7 +192,7 @@ public class TpceTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 						+ "VALUES (%s, '%s', '%s', '%s', '%s', '%s', %s, '%s', %d)", 
 						columns[0], columns[1], columns[2], columns[3], columns[4], 
 						columns[5], columns[6], columns[7], coOpenDate);
-				StoredProcedureHelper.executeUpdate(sql, tx);
+				StoredProcedureUtils.executeUpdate(sql, tx);
 			}
 			
 		});
@@ -209,7 +209,7 @@ public class TpceTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 				String sql = String.format("INSERT INTO last_trade (lt_s_symb, lt_dts, "
 						+ "lt_price, lt_open_price, lt_vol) VALUES ('%s', %d, %s, %s, %s)", 
 						columns[0], ltDts, columns[2], columns[3], columns[4]);
-				StoredProcedureHelper.executeUpdate(sql, tx);
+				StoredProcedureUtils.executeUpdate(sql, tx);
 			}
 			
 		});
@@ -234,7 +234,7 @@ public class TpceTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 						columns[1], columns[2], columns[3], columns[4], columns[5], 
 						columns[6], sStartDate, sExchDate, columns[9], columns[10], 
 						s52wkHighDate, columns[12], s52wkLowDate, columns[14], columns[15]);
-				StoredProcedureHelper.executeUpdate(sql, tx);
+				StoredProcedureUtils.executeUpdate(sql, tx);
 			}
 			
 		});

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpce/TradeOrderProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpce/TradeOrderProc.java
@@ -16,7 +16,7 @@
 package org.vanilladb.bench.server.procedure.tpce;
 
 import org.vanilladb.bench.server.param.tpce.TradeOrderParamHelper;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.core.query.algebra.Scan;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
 import org.vanilladb.core.storage.tx.Transaction;
@@ -56,7 +56,7 @@ public class TradeOrderProc extends StoredProcedure<TradeOrderParamHelper> {
 	 * Get customer, customer account, and broker information
 	 */
 	private void frame1() {
-		TradeOrderParamHelper paramHelper = getParamHelper();
+		TradeOrderParamHelper paramHelper = getHelper();
 		Transaction tx = getTransaction();
 		
 		// SELECT acct_name = ca_name, broker_id = ca_b_id, 
@@ -64,7 +64,7 @@ public class TradeOrderProc extends StoredProcedure<TradeOrderParamHelper> {
 		// customer_account WHERE ca_id = acct_id
 		String sql = "SELECT ca_name, ca_b_id, ca_c_id, ca_tax_st FROM customer_account"
 				+ " WHERE ca_id = " + paramHelper.getAcctId();
-		Scan s = StoredProcedureHelper.executeQuery(sql, tx);
+		Scan s = StoredProcedureUtils.executeQuery(sql, tx);
 		s.beforeFirst();
 		if (!s.next())
 			throw new RuntimeException("Executing '" + sql + "' fails");
@@ -82,7 +82,7 @@ public class TradeOrderProc extends StoredProcedure<TradeOrderParamHelper> {
 		// customer WHERE c_id = cust_id
 		sql = "SELECT c_f_name, c_l_name, c_tier, c_tax_id FROM customer"
 				+ " WHERE c_id = " + custId;
-		s = StoredProcedureHelper.executeQuery(sql, tx);
+		s = StoredProcedureUtils.executeQuery(sql, tx);
 		s.beforeFirst();
 		if (!s.next())
 			throw new RuntimeException("Executing '" + sql + "' fails");
@@ -94,7 +94,7 @@ public class TradeOrderProc extends StoredProcedure<TradeOrderParamHelper> {
 		
 		// SELECT broker_name = b_name FROM broker WHERE b_id = broker_id
 		sql = "SELECT b_name FROM broker WHERE b_id = " + brokerId;
-		s = StoredProcedureHelper.executeQuery(sql, tx);
+		s = StoredProcedureUtils.executeQuery(sql, tx);
 		s.beforeFirst();
 		if (!s.next())
 			throw new RuntimeException("Executing '" + sql + "' fails");
@@ -116,7 +116,7 @@ public class TradeOrderProc extends StoredProcedure<TradeOrderParamHelper> {
 	 * Estimate overall effects of the trade
 	 */
 	private void frame3() {
-		TradeOrderParamHelper paramHelper = getParamHelper();
+		TradeOrderParamHelper paramHelper = getHelper();
 		Transaction tx = getTransaction();
 		
 		// ===== Simplified Version =====
@@ -125,7 +125,7 @@ public class TradeOrderProc extends StoredProcedure<TradeOrderParamHelper> {
 		// FROM security WHERE s_symb = symbol
 		String sql = "SELECT s_co_id, s_ex_id, s_name FROM security WHERE "
 				+ "s_symb = " + paramHelper.getSymbol();
-		Scan s = StoredProcedureHelper.executeQuery(sql, tx);
+		Scan s = StoredProcedureUtils.executeQuery(sql, tx);
 		s.beforeFirst();
 		if (!s.next())
 			throw new RuntimeException("Executing '" + sql + "' fails");
@@ -138,7 +138,7 @@ public class TradeOrderProc extends StoredProcedure<TradeOrderParamHelper> {
 		// WHERE lt_s_symb = symbol
 		sql = "SELECT lt_price FROM last_trade WHERE "
 				+ "lt_s_symb = " + paramHelper.getSymbol();
-		s = StoredProcedureHelper.executeQuery(sql, tx);
+		s = StoredProcedureUtils.executeQuery(sql, tx);
 		s.beforeFirst();
 		if (!s.next())
 			throw new RuntimeException("Executing '" + sql + "' fails");
@@ -149,7 +149,7 @@ public class TradeOrderProc extends StoredProcedure<TradeOrderParamHelper> {
 		// FROM trade_type WHERE tt_id = trade_type_id
 		sql = "SELECT tt_is_mrkt, tt_is_sell FROM trade_type WHERE "
 				+ "tt_id = " + paramHelper.getTradeTypeId();
-		s = StoredProcedureHelper.executeQuery(sql, tx);
+		s = StoredProcedureUtils.executeQuery(sql, tx);
 		s.beforeFirst();
 		if (!s.next())
 			throw new RuntimeException("Executing '" + sql + "' fails");
@@ -202,7 +202,7 @@ public class TradeOrderProc extends StoredProcedure<TradeOrderParamHelper> {
 	 * Record the trade request by making all related updates
 	 */
 	private void frame4() {
-		TradeOrderParamHelper paramHelper = getParamHelper();
+		TradeOrderParamHelper paramHelper = getHelper();
 		Transaction tx = getTransaction();
 		long currentTime = System.currentTimeMillis();
 		
@@ -219,7 +219,7 @@ public class TradeOrderProc extends StoredProcedure<TradeOrderParamHelper> {
 				paramHelper.getTradeTypeId(), 1, paramHelper.getSymbol(),
 				paramHelper.getTradeQty(), marketPrice, paramHelper.getAcctId(), "exec_name",
 				paramHelper.getTradePrice(), 0.0, 0.0, 0.0, 1);
-		StoredProcedureHelper.executeUpdate(sql, tx);
+		StoredProcedureUtils.executeUpdate(sql, tx);
 		
 		// TODO: Implement this (not in the simplified version)
 		// Record pending trade information in TRADE_REQUEST table 
@@ -231,6 +231,6 @@ public class TradeOrderProc extends StoredProcedure<TradeOrderParamHelper> {
 		// INSERT INTO trade_history (th_t_id, th_dts, th_st_id) VALUES (...)
 		sql = String.format("INSERT INTO trade_history (th_t_id, th_dts, th_st_id) VALUES "
 				+ "(%d, %d, '%s')",  paramHelper.getTradeId(), currentTime, statusId);
-		StoredProcedureHelper.executeUpdate(sql, tx);
+		StoredProcedureUtils.executeUpdate(sql, tx);
 	}
 }

--- a/src/main/java/org/vanilladb/bench/server/procedure/tpce/TradeResultProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/tpce/TradeResultProc.java
@@ -16,7 +16,7 @@
 package org.vanilladb.bench.server.procedure.tpce;
 
 import org.vanilladb.bench.server.param.tpce.TradeResultParamHelper;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.core.query.algebra.Scan;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
 import org.vanilladb.core.storage.tx.Transaction;
@@ -29,14 +29,14 @@ public class TradeResultProc extends StoredProcedure<TradeResultParamHelper> {
 
 	@Override
 	protected void executeSql() {
-		TradeResultParamHelper paramHelper = getParamHelper();
+		TradeResultParamHelper paramHelper = getHelper();
 		Transaction tx = getTransaction();
 		
 		// SELECT ca_name, ca_b_id, ca_c_id FROM customer_account WHERE
 		// ca_id = acctId
 		String sql = "SELECT ca_name, ca_b_id, ca_c_id FROM customer_account WHERE "
 				+ "ca_id = " + paramHelper.getAcctId();
-		Scan s = StoredProcedureHelper.executeQuery(sql, tx);
+		Scan s = StoredProcedureUtils.executeQuery(sql, tx);
 		s.beforeFirst();
 		if (!s.next())
 			throw new RuntimeException("Executing '" + sql + "' fails");
@@ -46,7 +46,7 @@ public class TradeResultProc extends StoredProcedure<TradeResultParamHelper> {
 
 		// SELECT c_name FROM customer WHERE c_id = customerKey
 		sql = "SELECT c_f_name FROM customer WHERE c_id = " + paramHelper.getCustomerId();
-		s = StoredProcedureHelper.executeQuery(sql, tx);
+		s = StoredProcedureUtils.executeQuery(sql, tx);
 		s.beforeFirst();
 		if (!s.next())
 			throw new RuntimeException("Executing '" + sql + "' fails");
@@ -54,7 +54,7 @@ public class TradeResultProc extends StoredProcedure<TradeResultParamHelper> {
 
 		// SELECT b_name FROM broker WHERE b_id = brokerId
 		sql = "SELECT b_name FROM broker WHERE b_id = " + paramHelper.getBrokerId();
-		s = StoredProcedureHelper.executeQuery(sql, tx);
+		s = StoredProcedureUtils.executeQuery(sql, tx);
 		s.beforeFirst();
 		if (!s.next())
 			throw new RuntimeException("Executing '" + sql + "' fails");
@@ -62,7 +62,7 @@ public class TradeResultProc extends StoredProcedure<TradeResultParamHelper> {
 
 		// SELECT t_trade_price FROM trade WHERE t_id = tradeId
 		sql = "SELECT t_trade_price FROM trade WHERE t_id = " + paramHelper.getTradeId();
-		s = StoredProcedureHelper.executeQuery(sql, tx);
+		s = StoredProcedureUtils.executeQuery(sql, tx);
 		s.beforeFirst();
 		if (!s.next())
 			throw new RuntimeException("Executing '" + sql + "' fails");
@@ -72,12 +72,12 @@ public class TradeResultProc extends StoredProcedure<TradeResultParamHelper> {
 		long currentTime = System.currentTimeMillis();
 		sql = String.format("INSERT INTO trade_history (th_t_id, th_dts, th_st_id) VALUES "
 				+ "(%d, %d, '%s')",  paramHelper.getTradeId(), currentTime, "A");
-		StoredProcedureHelper.executeUpdate(sql, tx);
+		StoredProcedureUtils.executeUpdate(sql, tx);
 
 		// UPDATE customer_account SET ca_bal = ca_bal + tradePrice WHERE
 		// ca_id = acctId
 		sql = String.format("UPDATE customer_account SET ca_bal = %f WHERE ca_id = %d", 
 				1000.0, paramHelper.getAcctId());
-		StoredProcedureHelper.executeUpdate(sql, tx);
+		StoredProcedureUtils.executeUpdate(sql, tx);
 	}
 }

--- a/src/main/java/org/vanilladb/bench/server/procedure/ycsb/YcsbCheckDatabaseProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/ycsb/YcsbCheckDatabaseProc.java
@@ -4,16 +4,16 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.vanilladb.bench.benchmarks.ycsb.YcsbConstants;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.core.query.algebra.Scan;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 
-public class YcsbCheckDatabaseProc extends StoredProcedure<StoredProcedureParamHelper> {
+public class YcsbCheckDatabaseProc extends StoredProcedure<StoredProcedureHelper> {
 	private static Logger logger = Logger.getLogger(YcsbCheckDatabaseProc.class.getName());
 	
 	public YcsbCheckDatabaseProc() {
-		super(StoredProcedureParamHelper.newDefaultParamHelper());
+		super(StoredProcedureHelper.DEFAULT_HELPER);
 	}
 
 	@Override
@@ -41,7 +41,7 @@ public class YcsbCheckDatabaseProc extends StoredProcedure<StoredProcedureParamH
 		
 		// Scan the table
 		String sql = "SELECT ycsb_id FROM ycsb";
-		Scan scan = StoredProcedureHelper.executeQuery(sql, getTransaction());
+		Scan scan = StoredProcedureUtils.executeQuery(sql, getTransaction());
 		scan.beforeFirst();
 		for (int i = startIId, count = 0; i <= endIId; i++) {
 			if (!scan.next()) {

--- a/src/main/java/org/vanilladb/bench/server/procedure/ycsb/YcsbProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/ycsb/YcsbProc.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 
 import org.vanilladb.bench.benchmarks.ycsb.YcsbConstants;
 import org.vanilladb.bench.server.param.ycsb.YcsbBenchmarkProcParamHelper;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.core.query.algebra.Scan;
 import org.vanilladb.core.sql.Constant;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
@@ -18,13 +18,13 @@ public class YcsbProc extends StoredProcedure<YcsbBenchmarkProcParamHelper> {
 	
 	@Override
 	protected void executeSql() {
-		YcsbBenchmarkProcParamHelper paramHelper = getParamHelper();
+		YcsbBenchmarkProcParamHelper paramHelper = getHelper();
 		Transaction tx = getTransaction();
 
 		for (int idx = 0; idx < paramHelper.getReadCount(); idx++) {
 			String id = paramHelper.getReadIdStr(idx);
 			String sql = "SELECT ycsb_id, ycsb_1 FROM ycsb WHERE ycsb_id = '" + id + "'";
-			Scan s = StoredProcedureHelper.executeQuery(sql, tx);
+			Scan s = StoredProcedureUtils.executeQuery(sql, tx);
 			s.beforeFirst();
 			if (s.next()) {
 				String ycsb_1 = (String) s.getVal("ycsb_1").asJavaVal();
@@ -40,7 +40,7 @@ public class YcsbProc extends StoredProcedure<YcsbBenchmarkProcParamHelper> {
 			String id = paramHelper.getWriteIdStr(idx);
 			String newYcsbVal = paramHelper.getWriteValue(idx);
 			String sql = "UPDATE ycsb SET ycsb_1 = '" + newYcsbVal + "' WHERE ycsb_id = '" + id + "'";
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		}
 		
 		for (int idx = 0; idx < paramHelper.getInsertCount(); idx++) {
@@ -67,7 +67,7 @@ public class YcsbProc extends StoredProcedure<YcsbBenchmarkProcParamHelper> {
 			}
 			sql.append(")");
 			
-			StoredProcedureHelper.executeUpdate(sql.toString(), tx);
+			StoredProcedureUtils.executeUpdate(sql.toString(), tx);
 		}
 	}
 }

--- a/src/main/java/org/vanilladb/bench/server/procedure/ycsb/YcsbSchemaBuilderProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/ycsb/YcsbSchemaBuilderProc.java
@@ -1,7 +1,7 @@
 package org.vanilladb.bench.server.procedure.ycsb;
 
 import org.vanilladb.bench.server.param.ycsb.YcsbSchemaBuilderProcParamHelper;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
 import org.vanilladb.core.storage.tx.Transaction;
 
@@ -13,11 +13,11 @@ public class YcsbSchemaBuilderProc extends StoredProcedure<YcsbSchemaBuilderProc
 
 	@Override
 	protected void executeSql() {
-		YcsbSchemaBuilderProcParamHelper paramHelper = getParamHelper();
+		YcsbSchemaBuilderProcParamHelper paramHelper = getHelper();
 		Transaction tx = getTransaction();
 		for (String sql : paramHelper.getTableSchemas())
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 		for (String sql : paramHelper.getIndexSchemas())
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 	}
 }

--- a/src/main/java/org/vanilladb/bench/server/procedure/ycsb/YcsbStoredProcFactory.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/ycsb/YcsbStoredProcFactory.java
@@ -7,7 +7,7 @@ import org.vanilladb.core.sql.storedprocedure.StoredProcedureFactory;
 public class YcsbStoredProcFactory implements StoredProcedureFactory {
 
 	@Override
-	public StoredProcedure<?> getStroredProcedure(int pid) {
+	public StoredProcedure<?> getStoredProcedure(int pid) {
 		StoredProcedure<?> sp;
 		switch (YcsbTransactionType.fromProcedureId(pid)) {
 		case SCHEMA_BUILDER:

--- a/src/main/java/org/vanilladb/bench/server/procedure/ycsb/YcsbTestbedLoaderProc.java
+++ b/src/main/java/org/vanilladb/bench/server/procedure/ycsb/YcsbTestbedLoaderProc.java
@@ -4,19 +4,19 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.vanilladb.bench.benchmarks.ycsb.YcsbConstants;
-import org.vanilladb.bench.server.procedure.StoredProcedureHelper;
+import org.vanilladb.bench.server.procedure.StoredProcedureUtils;
 import org.vanilladb.core.server.VanillaDb;
 import org.vanilladb.core.sql.storedprocedure.StoredProcedure;
-import org.vanilladb.core.sql.storedprocedure.StoredProcedureParamHelper;
+import org.vanilladb.core.sql.storedprocedure.StoredProcedureHelper;
 import org.vanilladb.core.storage.tx.Transaction;
 import org.vanilladb.core.storage.tx.recovery.CheckpointTask;
 import org.vanilladb.core.storage.tx.recovery.RecoveryMgr;
 
-public class YcsbTestbedLoaderProc extends StoredProcedure<StoredProcedureParamHelper> {
+public class YcsbTestbedLoaderProc extends StoredProcedure<StoredProcedureHelper> {
 	private static Logger logger = Logger.getLogger(YcsbTestbedLoaderProc.class.getName());
 	
 	public YcsbTestbedLoaderProc() {
-		super(StoredProcedureParamHelper.newDefaultParamHelper());
+		super(StoredProcedureHelper.DEFAULT_HELPER);
 	}
 	
 	@Override
@@ -80,7 +80,7 @@ public class YcsbTestbedLoaderProc extends StoredProcedure<StoredProcedureParamH
 			}
 			sql += ")";
 
-			StoredProcedureHelper.executeUpdate(sql, tx);
+			StoredProcedureUtils.executeUpdate(sql, tx);
 			
 			if (recCount % 50000 == 0)
 				if (logger.isLoggable(Level.INFO))


### PR DESCRIPTION
As title. VanillaCore 0.7.0 updates the API of StoredProcedure and StoredProcedureParamHelper. In order to make VanillaBench works with it, I update the implementation of stored procedures.